### PR TITLE
Add note about Go compiler in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This driver is still an early Proof of Concept implementation that only
 implements the functions that are necessary for operating TLS servers like for
 example an HTTPS server.
 
+## Building
+
+Please use the [official Go compiler](https://go.dev/doc/install) for compiling the driver, the GNU Go compiler is currently not supported.
+
 ## Usage
 
 There is no documentation yet. But you can check out the `p11nethsm.conf` file,


### PR DESCRIPTION
The GNU Go compiler can compile the library, but during runtime the library crashes.
Adding note that GNU Go is currently unsupported and should not be used.

Fixes #3 