### PR TITLE
feat: clustering support

### DIFF
--- a/container/nginx/p11nethsm.conf
+++ b/container/nginx/p11nethsm.conf
@@ -1,8 +1,9 @@
 slots:
   - label: LocalHSM
     description: Local HSM (docker)
-    url: "https://192.168.3.161:8443/api/v1"
     operator:
       username: "operator"
       # password: "opPassphrase"
-    danger_insecure_cert: true  
+    instances:
+      - url: "https://192.168.3.161:8443/api/v1"
+        danger_insecure_cert: true

--- a/p11nethsm.conf
+++ b/p11nethsm.conf
@@ -1,4 +1,4 @@
-log_file: /tmp/p11nethsm.log
+# log_file: /tmp/p11nethsm.log
 slots:
   # - label: NetHSM1
   #   description: NetHSM Zone A
@@ -10,28 +10,22 @@ slots:
   #   password: "env:NETHSM_PASS" # operator password
   - label: LocalHSM
     description: Local HSM (docker)
-    url: "https://localhost:8443/api/v1"
     operator:
       username: "operator"
       password: "opPassphrase"
     administrator:
       username: "admin"
       password: "Administrator"
-    danger_insecure_cert: true  
-    # certificate: |
-    #     -----BEGIN CERTIFICATE-----
-    #     MIIBHjCBxaADAgECAgkApoJ3bQqnwmcwCgYIKoZIzj0EAwIwFDESMBAGA1UEAwwJ
-    #     a2V5ZmVuZGVyMCAXDTcwMDEwMTAwMDAwMFoYDzk5OTkxMjMxMjM1OTU5WjAUMRIw
-    #     EAYDVQQDDAlrZXlmZW5kZXIwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARzywjh
-    #     NQM4pBxNBIOrgWvKFcWle5SLGux1caV9rur/fnPptDnekjZ2fajJX2EEACjk9JKw
-    #     VykkfhbAdR46VGgFMAoGCCqGSM49BAMCA0gAMEUCIQDvm9J5y9S9POsfdlo5lKzg
-    #     VFYo7UBT3aTavB6b+hUUbQIgMzT1fBhbBFTgCx5LKQMp1V7SuyCby3oxL5RWYqhl
-    #     /R0=
-    #     -----END CERTIFICATE-----
-
-  # - label: LocalHSM
-  #   description: Local HSM (docker)
-  #   url: "https://localhost:8443/api/v1"
-  #   user: "admin"
-  #   password: "Administrator"
-  #   danger_insecure_cert: true
+    instances:
+      - url: "https://localhost:8443/api/v1"
+        danger_insecure_cert: true  
+        # certificate: |
+        #     -----BEGIN CERTIFICATE-----
+        #     MIIBHjCBxaADAgECAgkApoJ3bQqnwmcwCgYIKoZIzj0EAwIwFDESMBAGA1UEAwwJ
+        #     a2V5ZmVuZGVyMCAXDTcwMDEwMTAwMDAwMFoYDzk5OTkxMjMxMjM1OTU5WjAUMRIw
+        #     EAYDVQQDDAlrZXlmZW5kZXIwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARzywjh
+        #     NQM4pBxNBIOrgWvKFcWle5SLGux1caV9rur/fnPptDnekjZ2fajJX2EEACjk9JKw
+        #     VykkfhbAdR46VGgFMAoGCCqGSM49BAMCA0gAMEUCIQDvm9J5y9S9POsfdlo5lKzg
+        #     VFYo7UBT3aTavB6b+hUUbQIgMzT1fBhbBFTgCx5LKQMp1V7SuyCby3oxL5RWYqhl
+        #     /R0=
+        #     -----END CERTIFICATE-----

--- a/pkcs11/src/config/config_file.rs
+++ b/pkcs11/src/config/config_file.rs
@@ -84,18 +84,22 @@ pub struct P11Config {
     pub slots: Vec<SlotConfig>,
 }
 
-// A slot/server
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SlotConfig {
-    pub label: String,
-    pub description: Option<String>,
+pub struct InstanceConfig {
     pub url: String,
     #[serde(default)]
     pub danger_insecure_cert: bool,
-    pub operator: Option<UserConfig>,
-    pub administrator: Option<UserConfig>,
     pub certificate: Option<String>,
     pub certificate_file: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlotConfig {
+    pub label: String,
+    pub operator: Option<UserConfig>,
+    pub administrator: Option<UserConfig>,
+    pub description: Option<String>,
+    pub instances: Vec<InstanceConfig>,
 }
 
 // An user

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use openapi::apis::configuration::Configuration;
+
 use super::config_file::UserConfig;
 
 #[derive(Debug, Clone)]
@@ -9,24 +11,33 @@ pub struct Device {
 }
 
 #[derive(Debug, Clone)]
+pub struct ClusterInstance {
+    pub api_config: openapi::apis::configuration::Configuration,
+}
+
+#[derive(Debug, Clone)]
 pub struct Slot {
     pub label: String,
     pub description: Option<String>,
-    pub api_config: openapi::apis::configuration::Configuration,
+    pub instances: Vec<Configuration>,
     pub operator: Option<UserConfig>,
-    pub administator: Option<UserConfig>,
+    pub administrator: Option<UserConfig>,
 }
 
 impl Slot {
     // the user is connected if the basic auth is filled with an username and a password, otherwise the user will have to login
     pub fn is_connected(&self) -> bool {
-        self.api_config
-            .basic_auth
-            .as_ref()
-            .map(|auth| {
-                auth.1
+        self.instances
+            .get(0)
+            .map(|c| {
+                c.basic_auth
                     .as_ref()
-                    .map(|password| !password.is_empty())
+                    .map(|auth| {
+                        auth.1
+                            .as_ref()
+                            .map(|password| !password.is_empty())
+                            .unwrap_or(false)
+                    })
                     .unwrap_or(false)
             })
             .unwrap_or(false)

--- a/pkcs11/src/config/logging.rs
+++ b/pkcs11/src/config/logging.rs
@@ -20,8 +20,6 @@ pub fn configure_logger(config: &P11Config) {
                 .expect("could not open log file"),
         );
         builder.target(env_logger::Target::Pipe(file));
-    } else {
-        builder.target(env_logger::Target::Stdout);
     }
 
     builder.init()


### PR DESCRIPTION
You can now add multiple NetHSM instances in a "slot", the module will use the instances in a round-robin fashion and will failover to another instance if one sends a 412 or 5xx error.