### PR TITLE
feat: improve error management

### DIFF
--- a/pkcs11/src/api/encrypt.rs
+++ b/pkcs11/src/api/encrypt.rs
@@ -27,14 +27,17 @@ pub extern "C" fn C_EncryptInit(
     let mech = match Mechanism::from_ckraw_mech(&raw_mech) {
         Ok(mech) => mech,
         Err(e) => {
-            error!("C_EncryptInit() failed to convert mechanism: {:?}", e);
+            error!("C_EncryptInit() failed to convert mechanism: {}", e);
             return cryptoki_sys::CKR_MECHANISM_INVALID;
         }
     };
 
     lock_session!(hSession, session);
 
-    session.encrypt_init(&mech, hKey)
+    match session.encrypt_init(&mech, hKey) {
+        Ok(_) => cryptoki_sys::CKR_OK,
+        Err(e) => e.into(),
+    }
 }
 
 pub extern "C" fn C_Encrypt(
@@ -78,7 +81,7 @@ pub extern "C" fn C_Encrypt(
         Ok(data) => data,
         Err(e) => {
             session.encrypt_clear();
-            return e;
+            return e.into();
         }
     };
 
@@ -146,7 +149,7 @@ pub extern "C" fn C_EncryptUpdate(
         Ok(data) => data,
         Err(e) => {
             session.encrypt_clear();
-            return e;
+            return e.into();
         }
     };
 
@@ -202,7 +205,7 @@ pub extern "C" fn C_EncryptFinal(
         Ok(data) => data,
         Err(e) => {
             session.encrypt_clear();
-            return e;
+            return e.into();
         }
     };
 

--- a/pkcs11/src/api/generation.rs
+++ b/pkcs11/src/api/generation.rs
@@ -37,7 +37,7 @@ pub extern "C" fn C_GenerateKey(
     let mech = match Mechanism::from_ckraw_mech(&mech) {
         Ok(mech) => mech,
         Err(e) => {
-            error!("C_GenerateKey() failed to convert mechanism: {:?}", e);
+            error!("C_GenerateKey() failed to convert mechanism: {}", e);
             return cryptoki_sys::CKR_MECHANISM_INVALID;
         }
     };
@@ -99,7 +99,7 @@ pub extern "C" fn C_GenerateKeyPair(
     let mech = match Mechanism::from_ckraw_mech(&mech) {
         Ok(mech) => mech,
         Err(e) => {
-            error!("C_GenerateKeyPair() failed to convert mechanism: {:?}", e);
+            error!("C_GenerateKeyPair() failed to convert mechanism: {}", e);
             return cryptoki_sys::CKR_MECHANISM_INVALID;
         }
     };

--- a/pkcs11/src/api/object.rs
+++ b/pkcs11/src/api/object.rs
@@ -22,7 +22,10 @@ pub extern "C" fn C_FindObjectsInit(
         None
     };
     trace!("C_FindObjectsInit() template: {:?}", template);
-    session.enum_init(template)
+    match session.enum_init(template) {
+        Ok(_) => cryptoki_sys::CKR_OK,
+        Err(err) => err.into(),
+    }
 }
 
 pub extern "C" fn C_FindObjects(
@@ -43,8 +46,7 @@ pub extern "C" fn C_FindObjects(
     let objects = match session.enum_next_chunk(ulMaxObjectCount as usize) {
         Ok(objects) => objects,
         Err(err) => {
-            error!("C_FindObjects() failed: {:?}", err);
-            return err;
+            return err.into();
         }
     };
     trace!("C_FindObjects() objects: {:?}", objects);
@@ -154,8 +156,7 @@ pub extern "C" fn C_CreateObject(
     let objects = match session.create_object(template) {
         Ok(object) => object,
         Err(err) => {
-            error!("C_CreateObject() failed: {:?}", err);
-            return err;
+            return err.into();
         }
     };
 
@@ -192,7 +193,7 @@ pub extern "C" fn C_DestroyObject(
 
     match session.delete_object(hObject) {
         Ok(_) => cryptoki_sys::CKR_OK,
-        Err(err) => err,
+        Err(err) => err.into(),
     }
 }
 

--- a/pkcs11/src/api/pin.rs
+++ b/pkcs11/src/api/pin.rs
@@ -2,7 +2,6 @@
     We won't implement these function as it is not a feature of NetHSM.
 */
 
-use cryptoki_sys::CKR_OK;
 use log::{error, trace};
 
 use crate::{lock_mutex, lock_session};
@@ -45,8 +44,8 @@ pub extern "C" fn C_SetPIN(
         Err(_) => return cryptoki_sys::CKR_ARGUMENTS_BAD,
     };
 
-    if CKR_OK != session.login(cryptoki_sys::CKU_USER, old_pin.to_string()) {
-        return cryptoki_sys::CKR_PIN_INCORRECT;
+    if let Err(err) = session.login(cryptoki_sys::CKU_USER, old_pin.to_string()) {
+        return err.into();
     }
 
     if !session

--- a/pkcs11/src/backend/decrypt.rs
+++ b/pkcs11/src/backend/decrypt.rs
@@ -1,14 +1,13 @@
 use base64::{engine::general_purpose, Engine};
-use cryptoki_sys::{
-    CKR_ARGUMENTS_BAD, CKR_DEVICE_ERROR, CKR_MECHANISM_INVALID, CKR_USER_NOT_LOGGED_IN, CK_RV,
-};
-use log::{error, trace};
+
+use log::trace;
 use openapi::apis::default_api;
 
 use super::{
     db::Object,
     login::{self, LoginCtx},
     mechanism::{MechMode, Mechanism},
+    Error,
 };
 
 #[derive(Clone, Debug)]
@@ -20,31 +19,26 @@ pub struct DecryptCtx {
 }
 
 impl DecryptCtx {
-    pub fn init(mechanism: Mechanism, key: &Object, login_ctx: &LoginCtx) -> Result<Self, CK_RV> {
+    pub fn init(mechanism: Mechanism, key: &Object, login_ctx: &LoginCtx) -> Result<Self, Error> {
         let login_ctx = login_ctx.clone();
 
         if !login_ctx.can_run_mode(login::UserMode::Operator) {
-            error!("No operator is logged in");
-            return Err(CKR_USER_NOT_LOGGED_IN);
+            return Err(Error::NotLoggedIn(login::UserMode::Operator));
         }
 
-        let api_mech = match mechanism.to_api_mech(MechMode::Decrypt) {
-            Some(mech) => mech,
-            None => {
-                error!(
-                    "Tried to decrypt with an invalid mechanism: {:?}",
-                    mechanism
-                );
-                return Err(CKR_MECHANISM_INVALID);
-            }
-        };
+        let api_mech =
+            mechanism
+                .to_api_mech(MechMode::Decrypt)
+                .ok_or(Error::InvalidMechanismMode(
+                    MechMode::Decrypt,
+                    mechanism.clone(),
+                ))?;
 
         if !key.mechanisms.contains(&api_mech) {
-            error!(
-                "Tried to decrypt with an invalid mechanism: {:?}",
-                mechanism
-            );
-            return Err(CKR_MECHANISM_INVALID);
+            return Err(Error::InvalidMechanism(
+                (key.id.clone(), key.kind),
+                mechanism,
+            ));
         }
 
         Ok(Self {
@@ -58,10 +52,16 @@ impl DecryptCtx {
         self.data.extend_from_slice(data);
     }
 
-    pub fn decrypt_final(&mut self) -> Result<Vec<u8>, cryptoki_sys::CK_RV> {
+    pub fn decrypt_final(&mut self) -> Result<Vec<u8>, Error> {
         let b64_message = general_purpose::STANDARD.encode(self.data.as_slice());
 
-        let mode = self.mechanism.decrypt_name().ok_or(CKR_ARGUMENTS_BAD)?;
+        let mode = self
+            .mechanism
+            .decrypt_name()
+            .ok_or(Error::InvalidMechanismMode(
+                MechMode::Decrypt,
+                self.mechanism.clone(),
+            ))?;
         trace!("Signing with mode: {:?}", mode);
 
         let iv = self
@@ -69,32 +69,21 @@ impl DecryptCtx {
             .iv()
             .map(|iv| general_purpose::STANDARD.encode(iv.as_slice()));
 
-        let output = self
-            .login_ctx
-            .try_(
-                |api_config| {
-                    default_api::keys_key_id_decrypt_post(
-                        api_config,
-                        &self.key_id,
-                        openapi::models::DecryptRequestData {
-                            mode,
-                            encrypted: b64_message,
-                            iv,
-                        },
-                    )
-                },
-                login::UserMode::Operator,
-            )
-            .map_err(|err| {
-                error!("Failed to decrypt: {:?}", err);
-                CKR_DEVICE_ERROR
-            })?;
+        let output = self.login_ctx.try_(
+            |api_config| {
+                default_api::keys_key_id_decrypt_post(
+                    api_config,
+                    &self.key_id,
+                    openapi::models::DecryptRequestData {
+                        mode,
+                        encrypted: b64_message,
+                        iv,
+                    },
+                )
+            },
+            login::UserMode::Operator,
+        )?;
 
-        general_purpose::STANDARD
-            .decode(output.decrypted)
-            .map_err(|err: base64::DecodeError| {
-                error!("Failed to decode signature: {:?}", err);
-                CKR_DEVICE_ERROR
-            })
+        Ok(general_purpose::STANDARD.decode(output.decrypted)?)
     }
 }

--- a/pkcs11/src/backend/sign.rs
+++ b/pkcs11/src/backend/sign.rs
@@ -2,10 +2,11 @@ use super::{
     db::Object,
     login::{self, LoginCtx},
     mechanism::{MechMode, Mechanism},
+    Error,
 };
 use base64::{engine::general_purpose, Engine as _};
-use cryptoki_sys::{CKR_DEVICE_ERROR, CKR_MECHANISM_INVALID, CKR_USER_NOT_LOGGED_IN, CK_RV};
-use log::{debug, error, trace};
+
+use log::{debug, trace};
 use openapi::{apis::default_api, models::SignMode};
 
 #[derive(Clone, Debug)]
@@ -18,26 +19,25 @@ pub struct SignCtx {
 }
 
 impl SignCtx {
-    pub fn init(mechanism: Mechanism, key: Object, login_ctx: &LoginCtx) -> Result<Self, CK_RV> {
+    pub fn init(mechanism: Mechanism, key: Object, login_ctx: &LoginCtx) -> Result<Self, Error> {
         let login_ctx = login_ctx.clone();
 
         trace!("key_type: {:?}", key.kind);
 
         if !login_ctx.can_run_mode(login::UserMode::Operator) {
-            debug!("No operator is logged in");
-            return Err(CKR_USER_NOT_LOGGED_IN);
+            return Err(Error::NotLoggedIn(login::UserMode::Operator));
         }
 
         let sign_name = mechanism.sign_name().ok_or_else(|| {
             debug!("Tried to sign with an invalid mechanism: {:?}", mechanism);
-            CKR_MECHANISM_INVALID
+            Error::InvalidMechanismMode(MechMode::Sign, mechanism.clone())
         })?;
 
         let api_mech = match mechanism.to_api_mech(MechMode::Sign) {
             Some(mech) => mech,
             None => {
                 debug!("Tried to sign with an invalid mechanism: {:?}", mechanism);
-                return Err(CKR_MECHANISM_INVALID);
+                return Err(Error::InvalidMechanismMode(MechMode::Sign, mechanism));
             }
         };
 
@@ -49,7 +49,7 @@ impl SignCtx {
                 "Tried to sign with an invalid mechanism for this key: {:?}",
                 mechanism
             );
-            return Err(CKR_MECHANISM_INVALID);
+            return Err(Error::InvalidMechanism((key.id, key.kind), mechanism));
         }
 
         Ok(Self {
@@ -64,38 +64,27 @@ impl SignCtx {
         self.data.extend_from_slice(data);
     }
 
-    pub fn sign_final(&mut self) -> Result<Vec<u8>, cryptoki_sys::CK_RV> {
+    pub fn sign_final(&mut self) -> Result<Vec<u8>, Error> {
         let b64_message = general_purpose::STANDARD.encode(self.data.as_slice());
 
         let mode = self.sign_name;
         trace!("Signing with mode: {:?}", mode);
 
-        let signature = self
-            .login_ctx
-            .try_(
-                |conf| {
-                    default_api::keys_key_id_sign_post(
-                        conf,
-                        &self.key.id.clone(),
-                        openapi::models::SignRequestData {
-                            mode,
-                            message: b64_message,
-                        },
-                    )
-                },
-                login::UserMode::Operator,
-            )
-            .map_err(|err| {
-                error!("Failed to sign: {:?}", err);
-                CKR_DEVICE_ERROR
-            })?;
+        let signature = self.login_ctx.try_(
+            |conf| {
+                default_api::keys_key_id_sign_post(
+                    conf,
+                    &self.key.id.clone(),
+                    openapi::models::SignRequestData {
+                        mode,
+                        message: b64_message,
+                    },
+                )
+            },
+            login::UserMode::Operator,
+        )?;
 
-        general_purpose::STANDARD
-            .decode(signature.signature)
-            .map_err(|err| {
-                error!("Failed to decode signature: {:?}", err);
-                CKR_DEVICE_ERROR
-            })
+        Ok(general_purpose::STANDARD.decode(signature.signature)?)
     }
 
     pub fn get_theoretical_size(&self) -> usize {


### PR DESCRIPTION
Theres is now a new Error type that is used to return errors to the user. This type should be used in the `backend` folder to return errors. These errors are then converted to CK_RV.