### PR TITLE
utils: Replace padded_str macro with function

### DIFF
--- a/pkcs11/src/api/mod.rs
+++ b/pkcs11/src/api/mod.rs
@@ -16,7 +16,8 @@ pub mod verify;
 use crate::{
     backend::events::{fetch_slots_state, EventsManager},
     data::{self, DEVICE, EVENTS_MANAGER, THREADS_ALLOWED, TOKENS_STATE},
-    defs, padded_str,
+    defs,
+    utils::padded_str,
 };
 use cryptoki_sys::{CK_INFO, CK_INFO_PTR, CK_RV, CK_VOID_PTR};
 use log::{debug, trace};
@@ -99,9 +100,9 @@ pub extern "C" fn C_GetInfo(pInfo: CK_INFO_PTR) -> CK_RV {
 
     let infos = CK_INFO {
         cryptokiVersion: defs::CRYPTOKI_VERSION,
-        manufacturerID: padded_str!(defs::LIB_MANUFACTURER, 32),
+        manufacturerID: padded_str(defs::LIB_MANUFACTURER),
         flags: 0,
-        libraryDescription: padded_str!(defs::LIB_DESCRIPTION, 32),
+        libraryDescription: padded_str(defs::LIB_DESCRIPTION),
         libraryVersion: defs::LIB_VERSION,
     };
 

--- a/pkcs11/src/api/token.rs
+++ b/pkcs11/src/api/token.rs
@@ -16,8 +16,8 @@ use crate::{
     },
     data::{DEVICE, EVENTS_MANAGER},
     defs::{DEFAULT_FIRMWARE_VERSION, DEFAULT_HARDWARE_VERSION, MECHANISM_LIST},
-    lock_session, padded_str,
-    utils::version_struct_from_str,
+    lock_session,
+    utils::{padded_str, version_struct_from_str},
 };
 
 pub extern "C" fn C_GetSlotList(
@@ -129,8 +129,8 @@ pub extern "C" fn C_GetSlotInfo(
     }
 
     let info: CK_SLOT_INFO = CK_SLOT_INFO {
-        slotDescription: padded_str!(&info.product, 64),
-        manufacturerID: padded_str!(info.vendor, 32),
+        slotDescription: padded_str(&info.product),
+        manufacturerID: padded_str(&info.vendor),
         flags,
         hardwareVersion: DEFAULT_HARDWARE_VERSION,
         firmwareVersion: DEFAULT_FIRMWARE_VERSION,
@@ -209,10 +209,10 @@ pub extern "C" fn C_GetTokenInfo(
     }
 
     let token_info = CK_TOKEN_INFO {
-        label: padded_str!(slot.label, 32),
-        manufacturerID: padded_str!(info.entity.vendor, 32),
-        model: padded_str!(info.entity.product, 16),
-        serialNumber: padded_str!(serial_number, 16),
+        label: padded_str(&slot.label),
+        manufacturerID: padded_str(&info.entity.vendor),
+        model: padded_str(&info.entity.product),
+        serialNumber: padded_str(&serial_number),
         flags,
         hardwareVersion: hardware_version,
         firmwareVersion: firmware_version,

--- a/pkcs11/src/utils.rs
+++ b/pkcs11/src/utils.rs
@@ -63,12 +63,9 @@ macro_rules! read_session {
 // Modified from the ACM project : https://github.com/aws/aws-nitro-enclaves-acm/blob/main/src/vtok_p11/src/util/mod.rs
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-#[macro_export]
-macro_rules! padded_str {
-    ($src:expr, $len: expr) => {{
-        let mut ret = [b' '; $len];
-        let count = std::cmp::min($src.len(), $len);
-        ret[..count].copy_from_slice(&$src.as_bytes()[..count]);
-        ret
-    }};
+pub fn padded_str<const N: usize>(s: &str) -> [u8; N] {
+    let mut ret = [b' '; N];
+    let count = std::cmp::min(s.len(), N);
+    ret[..count].copy_from_slice(&s.as_bytes()[..count]);
+    ret
 }


### PR DESCRIPTION
This patch replaces the padded_str macro with a function using const generics.