### PR TITLE
Add support for syslog logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +200,15 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -252,6 +270,17 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
 
 [[package]]
 name = "humantime"
@@ -331,6 +360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "merge"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,7 +424,17 @@ dependencies = [
  "serde_yaml",
  "sha1",
  "sha2",
+ "syslog",
  "x509-cert",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -418,6 +463,12 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro-error"
@@ -704,12 +755,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "syslog"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7434e95bcccce1215d30f4bf84fe8c00e8de1b9be4fb736d747ca53d36e7f96f"
+dependencies = [
+ "error-chain",
+ "hostname",
+ "libc",
+ "log",
+ "time",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "time"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/p11nethsm.example.conf
+++ b/p11nethsm.example.conf
@@ -6,14 +6,17 @@ enable_set_attribute_value: false
 
 # Optional log level, acceptable  values are Trace, Debug, Info, Warn and Error
 log_level: Debug
-# By default, the module logs to syslog, trying the sockets /dev/log, /var/run/syslog and finally /var/run/log
+
+# By default, the module logs to both syslog and stderr, trying the sockets /dev/log, /var/run/syslog and finally /var/run/log
 # A custom socket can be configured:
 syslog_socket: /var/nethsm/log
-# A custom UDP or TCP syslog can be configured:
+# Instead of a socket, a custom UDP or TCP syslog can be configured:
 # syslog_udp: 
 #    to_addr: 127.0.0:1:514
 #    from_addr: 127.0.0:1:4789
 # syslog_tcp: 127.0.0.1:601
+# Only one option among "syslog_socket", "syslog_udp", "syslog_tcp" can be configured at the same time
+
 # You can configure the syslog facility ( "kern", "user", "mail", "daemon", "auth", "syslog", "lpr", "news", "uucp", "cron", "authpriv", "ftp", "local0", "local1", "local2", "local3", "local4", "local5", "local6" or "local7"):
 syslog_facility: "user"
 # You can set the hostname (for use only with syslog_udp or syslog_tcp)
@@ -22,9 +25,8 @@ syslog_facility: "user"
 # syslog_process: "NetHSM Pkcs11"
 # You can set the pid used in logs (defaults to the process id obtained from the OS)
 # syslog_pid: 0
-# If not using Syslog, you can configure a custom file, or "-" for stderr. Incompatible with any "syslog_*"" option
+# You can also configure a custom file, or "-" for stderr.
 # log_file: /tmp/p11nethsm.log
-# Only one option among "syslog_socket", "syslog_udp", "syslog_tcp", and "log_file" can be configured at the same time
 
 # Each "slot" represents a HSM cluster of server that share the same user and keys.
 slots:

--- a/p11nethsm.example.conf
+++ b/p11nethsm.example.conf
@@ -4,12 +4,27 @@
 # Under the hood it will store in memory the name given to the key when calling C_SetAttributeValue(). When a certificate is uploaded it will check if the name was previously passed to C_SetAttributeValue() and translate it to the real name on the NetHSM.
 enable_set_attribute_value: false
 
-# You can set the log file location here.
-# If no value is set the module will output to stderr.
-# If a value is set it will output to the file.
-log_file: /tmp/p11nethsm.log
 # Optional log level, acceptable  values are Trace, Debug, Info, Warn and Error
 log_level: Debug
+# By default, the module logs to syslog, trying the sockets /dev/log, /var/run/syslog and finally /var/run/log
+# A custom socket can be configured:
+syslog_socket: /var/nethsm/log
+# A custom UDP or TCP syslog can be configured:
+# syslog_udp: 
+#    to_addr: 127.0.0:1:514
+#    from_addr: 127.0.0:1:4789
+# syslog_tcp: 127.0.0.1:601
+# You can configure the syslog facility ( "kern", "user", "mail", "daemon", "auth", "syslog", "lpr", "news", "uucp", "cron", "authpriv", "ftp", "local0", "local1", "local2", "local3", "local4", "local5", "local6" or "local7"):
+syslog_facility: "user"
+# You can set the hostname (for use only with syslog_udp or syslog_tcp)
+# syslog_hostname: "localhsm-pkcs11"
+# You can set the process name (defaults to the process name obtained from the OS)
+# syslog_process: "NetHSM Pkcs11"
+# You can set the pid used in logs (defaults to the process id obtained from the OS)
+# syslog_pid: 0
+# If not using Syslog, you can configure a custom file, or "-" for stderr. Incompatible with any "syslog_*"" option
+# log_file: /tmp/p11nethsm.log
+# Only one option among "syslog_socket", "syslog_udp", "syslog_tcp", and "log_file" can be configured at the same time
 
 # Each "slot" represents a HSM cluster of server that share the same user and keys.
 slots:

--- a/pkcs11/Cargo.toml
+++ b/pkcs11/Cargo.toml
@@ -36,6 +36,7 @@ sha2 = { default-features = false, version = "0.10" }
 sha1 = { default-features = false, version = "0.10" }
 digest = { default-features = false, version = "0.10" }
 rayon = "1.8.0"
+syslog = "6.1.0"
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/pkcs11/src/api/mod.rs
+++ b/pkcs11/src/api/mod.rs
@@ -58,7 +58,7 @@ pub extern "C" fn C_Initialize(pInitArgs: CK_VOID_PTR) -> CK_RV {
     match result {
         Ok(()) => {}
         Err(err) => {
-            error!("Failed to initialize configuration: {err:?}");
+            error!("NetHSM PKCS#11: Failed to initialize configuration: {err:?}");
             return cryptoki_sys::CKR_FUNCTION_FAILED;
         }
     }

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 use nethsm_sdk_rs::apis::configuration::Configuration;
 
@@ -9,7 +12,7 @@ use super::config_file::{RetryConfig, UserConfig};
 // stores the global configuration of the module
 #[derive(Debug, Clone)]
 pub struct Device {
-    pub log_file: Option<String>,
+    pub log_file: Option<PathBuf>,
     pub slots: Vec<Arc<Slot>>,
     pub enable_set_attribute_value: bool,
 }

--- a/pkcs11/src/config/initialization.rs
+++ b/pkcs11/src/config/initialization.rs
@@ -227,7 +227,7 @@ slots:
             "#.into(),
         ];
 
-        assert!(initialize_with_configs(configs).is_ok());
+        assert!(initialize_with_configs(Ok(configs)).is_ok());
 
         let configs_bad_fingerprint: Vec<Vec<u8>> = vec![
             r#"
@@ -251,12 +251,12 @@ slots:
     timeout_seconds: 10
             "#.into(),
         ];
-        assert!(initialize_with_configs(configs_bad_fingerprint).is_err());
+        assert!(initialize_with_configs(Ok(configs_bad_fingerprint)).is_err());
         let configs_bad_yml: Vec<Vec<u8>> = vec![r#"
 dict:
 bad_yml
             "#
         .into()];
-        assert!(initialize_with_configs(configs_bad_yml).is_err());
+        assert!(initialize_with_configs(Ok(configs_bad_yml)).is_err());
     }
 }

--- a/pkcs11/src/config/logging.rs
+++ b/pkcs11/src/config/logging.rs
@@ -145,6 +145,7 @@ pub fn configure_logger(config: &Result<P11Config, InitializationError>) {
                 messages.push("Failed to create UDP logger".to_string());
             }
         } else {
+            #[allow(clippy::collapsible_else_if)]
             if let Ok(logger) = syslog::unix(formatter) {
                 syslog_logger = Some(BasicLogger::new(logger));
                 info_messages.push("Logging to standard Unix socket".into());

--- a/pkcs11/src/config/logging.rs
+++ b/pkcs11/src/config/logging.rs
@@ -1,10 +1,16 @@
-use super::{config_file::P11Config, initialization::InitializationError};
+use log::{info, warn};
+use syslog::{BasicLogger, Formatter3164};
+
+use super::{
+    config_file::{LogLevel, P11Config},
+    initialization::InitializationError,
+};
 
 // output to stdout, a file or syslog
 pub fn configure_logger(config: &Result<P11Config, InitializationError>) {
     let Ok(config) = config else {
         // On error, first try logging to syslog
-        if syslog::init(syslog::Facility::LOG_USER, log::LevelFilter::Info, None).is_ok() {
+        if syslog::init_unix(syslog::Facility::LOG_USER, log::LevelFilter::Info).is_ok() {
             return;
         };
         // Otherwise try to log to stderr
@@ -12,36 +18,149 @@ pub fn configure_logger(config: &Result<P11Config, InitializationError>) {
         return;
     };
 
-    let mut builder = env_logger::Builder::from_default_env();
+    let log_level = config.log_level.unwrap_or(LogLevel::Warn);
 
-    // set the log level
+    let mut currently_logging = "Failed to set a logger";
 
-    if let Some(level) = &config.log_level {
-        builder.filter_level(level.into());
+    // Warning messages for invalid configuration
+    let mut messages = Vec::new();
+    if config.syslog_socket.is_some() as u32
+        + config.syslog_tcp.is_some() as u32
+        + config.syslog_udp.is_some() as u32
+        > 1
+    {
+        messages.push("Multiple syslog target selected".to_string());
     }
 
-    if let Some(path) = &config.log_file {
-        // get the current rights of the file
-        if let Ok(metadata) = std::fs::metadata(path) {
-            let mut permissions = metadata.permissions();
-            if permissions.readonly() {
-                #[allow(clippy::permissions_set_readonly_false)]
-                permissions.set_readonly(false);
-                std::fs::set_permissions(path, permissions).unwrap();
+    let use_syslog = config.syslog_socket.is_some()
+        || config.syslog_tcp.is_some()
+        || config.syslog_udp.is_some()
+        || config.syslog_facility.is_some()
+        || config.syslog_hostname.is_some()
+        || config.syslog_process.is_some()
+        || config.syslog_pid.is_some();
+
+    let use_file = config.log_file.is_some();
+
+    if use_syslog && use_file {
+        messages.push("Cannot log both to file and to syslog".to_string())
+    }
+
+    // syslog is used if neither syslog nor file is configured
+    if use_syslog || !use_file {
+        let facility = config
+            .syslog_facility
+            .as_ref()
+            .map(|f| match f.parse() {
+                Ok(facility) => facility,
+                Err(_) => {
+                    messages.push(format!(
+                        "Failed to parse {f} as facility. Defaulting to LOG_USER"
+                    ));
+                    Default::default()
+                }
+            })
+            .unwrap_or_default();
+
+        let process_name = || {
+            let Ok(current_exe) = std::env::current_exe() else {
+                return "Unknown".into();
+            };
+            current_exe.as_os_str().to_string_lossy().into_owned()
+        };
+
+        if let Some(path) = &config.syslog_socket {
+            syslog::init_unix_custom(facility, log_level.into(), path).ok();
+            if config.syslog_hostname.is_some()
+                || config.syslog_process.is_some()
+                || config.syslog_pid.is_some()
+            {
+                messages.push(
+                    "Cannot configure PID, Process  name or hostname when logging to unix socket"
+                        .into(),
+                );
+            }
+            currently_logging = "Logging to unix socket";
+        } else if let Some(addr) = config.syslog_tcp {
+            let formatter = Formatter3164 {
+                facility,
+                hostname: config.syslog_hostname.clone(),
+                process: config.syslog_process.clone().unwrap_or_else(process_name),
+                pid: config.syslog_pid.unwrap_or_else(std::process::id),
+            };
+            if let Ok(logger) = syslog::tcp(formatter, addr) {
+                log::set_boxed_logger(Box::new(BasicLogger::new(logger))).ok();
+                currently_logging = "Logging to TCP";
+            } else {
+                messages.push("Failed to create TCP logger".to_string());
+            }
+        } else if let Some(udp_conf) = config.syslog_udp {
+            let formatter = Formatter3164 {
+                facility,
+                hostname: config.syslog_hostname.clone(),
+                process: config.syslog_process.clone().unwrap_or_else(process_name),
+                pid: config.syslog_pid.unwrap_or_else(std::process::id),
+            };
+            if let Ok(logger) = syslog::udp(formatter, udp_conf.from_addr, udp_conf.to_addr) {
+                log::set_boxed_logger(Box::new(BasicLogger::new(logger))).ok();
+                currently_logging = "Logging to UDP";
+            } else {
+                messages.push("Failed to create UDP logger".to_string());
+            }
+        } else {
+            syslog::init_unix(facility, log_level.into()).ok();
+            if config.syslog_hostname.is_some()
+                || config.syslog_process.is_some()
+                || config.syslog_pid.is_some()
+            {
+                messages.push(
+                    "Cannot configure PID, Process  name or hostname when logging to unix socket"
+                        .into(),
+                );
+            }
+            currently_logging = "Logging to unix socket";
+        }
+    } else {
+        let mut builder = env_logger::Builder::from_default_env();
+
+        // set the log level
+
+        builder.filter_level(log_level.into());
+
+        if let Some(path) = &config.log_file {
+            if path.as_os_str() == "-" {
+                builder.target(env_logger::Target::Stderr);
+                currently_logging = "Logging to STDERR";
+            } else {
+                currently_logging = "Logging to File";
+                // get the current rights of the file
+                if let Ok(metadata) = std::fs::metadata(path) {
+                    let mut permissions = metadata.permissions();
+                    if permissions.readonly() {
+                        #[allow(clippy::permissions_set_readonly_false)]
+                        permissions.set_readonly(false);
+                        std::fs::set_permissions(path, permissions).unwrap();
+                    }
+                }
+
+                // open the file for appending
+                let file = Box::new(
+                    std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(path)
+                        .expect("could not open log file"),
+                );
+                builder.target(env_logger::Target::Pipe(file));
             }
         }
 
-        // open the file for appending
-        let file = Box::new(
-            std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(path)
-                .expect("could not open log file"),
-        );
-        builder.target(env_logger::Target::Pipe(file));
+        // Don't crash on re-initialization
+        builder.try_init().ok();
     }
 
-    // Don't crash on re-initialization
-    builder.try_init().ok();
+    info!("{currently_logging}");
+    for m in messages {
+        warn!("{m}");
+    }
 }

--- a/pkcs11/src/config/logging.rs
+++ b/pkcs11/src/config/logging.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use log::{info, warn, LevelFilter};
 use syslog::{BasicLogger, Formatter3164};
 
@@ -39,8 +41,8 @@ impl log::Log for MultiLog {
 }
 
 // output to stdout, a file or syslog
-pub fn configure_logger(config: &Result<P11Config, InitializationError>) {
-    let Ok(config) = config else {
+pub fn configure_logger(config: &Result<(P11Config, Vec<PathBuf>), InitializationError>) {
+    let Ok((config, file_paths)) = config else {
         let formatter = Formatter3164 {
             facility: syslog::Facility::LOG_USER,
             hostname: None,
@@ -66,6 +68,11 @@ pub fn configure_logger(config: &Result<P11Config, InitializationError>) {
     let mut messages = Vec::new();
     // Info messages to log after logger is configured
     let mut info_messages = Vec::new();
+
+    for path in file_paths {
+        info_messages.push(format!("Loaded config file at: {}", path.to_string_lossy()));
+    }
+
     if config.syslog_socket.is_some() as u32
         + config.syslog_tcp.is_some() as u32
         + config.syslog_udp.is_some() as u32


### PR DESCRIPTION
This patch adds support for syslog logging.

On initialization errors, it will also now by default log to syslog, instead of logging to stderr. Ideally it would do both, but there doesn't appear to be an easy way to support multiple loggers at the same time.

I also want to revert https://github.com/Nitrokey/nethsm-pkcs11/commit/3a635b423a286f66e87e23136089d93b219049c9, this seems like a security concern as it makes the log file writeable by anyone. What was the justification for this  change? I also want to not panic if the file can't be opened as is currently the case.

Fix https://github.com/Nitrokey/nethsm-pkcs11/issues/153