### PR TITLE
Fix TCP connection timeout

### DIFF
--- a/pkcs11/src/config/initialization.rs
+++ b/pkcs11/src/config/initialization.rs
@@ -147,7 +147,9 @@ fn slot_from_config(slot: &SlotConfig) -> Result<Slot, InitializationError> {
             .max_idle_connections_per_host(max_idle_connections);
 
         if let Some(t) = slot.timeout_seconds {
-            builder = builder.timeout(Duration::from_secs(t));
+            builder = builder
+                .timeout(Duration::from_secs(t))
+                .timeout_connect(Duration::from_secs(10));
         }
 
         let agent = builder.build();


### PR DESCRIPTION
`Ureq` does not use the `timeout` for the opening of the TCP connection, and instead uses the default timeout of 30s.

See https://github.com/algesten/ureq/issues/595#issuecomment-1904161215