### PR TITLE
Fix certutil certificate listing

### DIFF
--- a/pkcs11/src/backend/db/object.rs
+++ b/pkcs11/src/backend/db/object.rs
@@ -8,9 +8,9 @@ use cryptoki_sys::{
     CKA_EC_PARAMS, CKA_EC_POINT, CKA_ENCRYPT, CKA_EXTRACTABLE, CKA_ID, CKA_ISSUER,
     CKA_KEY_GEN_MECHANISM, CKA_KEY_TYPE, CKA_LABEL, CKA_LOCAL, CKA_MODIFIABLE, CKA_MODULUS,
     CKA_MODULUS_BITS, CKA_NEVER_EXTRACTABLE, CKA_PRIVATE, CKA_PUBLIC_EXPONENT, CKA_SENSITIVE,
-    CKA_SIGN, CKA_SIGN_RECOVER, CKA_SUBJECT, CKA_TOKEN, CKA_TRUSTED, CKA_UNWRAP, CKA_VALUE,
-    CKA_VALUE_LEN, CKA_VERIFY, CKA_VERIFY_RECOVER, CKA_WRAP, CKA_WRAP_WITH_TRUSTED, CKC_X_509,
-    CK_ATTRIBUTE_TYPE, CK_KEY_TYPE, CK_MECHANISM_TYPE, CK_OBJECT_CLASS, CK_ULONG,
+    CKA_SERIAL_NUMBER, CKA_SIGN, CKA_SIGN_RECOVER, CKA_SUBJECT, CKA_TOKEN, CKA_TRUSTED, CKA_UNWRAP,
+    CKA_VALUE, CKA_VALUE_LEN, CKA_VERIFY, CKA_VERIFY_RECOVER, CKA_WRAP, CKA_WRAP_WITH_TRUSTED,
+    CKC_X_509, CK_ATTRIBUTE_TYPE, CK_KEY_TYPE, CK_MECHANISM_TYPE, CK_OBJECT_CLASS, CK_ULONG,
     CK_UNAVAILABLE_INFORMATION,
 };
 use der::{asn1::OctetString, DecodePem, Encode};
@@ -467,6 +467,15 @@ pub fn from_cert_data(
         CKA_ISSUER,
         Attr::Bytes(cert.tbs_certificate.issuer.to_der().map_err(Error::Der)?),
     );
+    attrs.insert(
+        CKA_SERIAL_NUMBER,
+        Attr::Bytes(
+            cert.tbs_certificate
+                .serial_number
+                .to_der()
+                .map_err(Error::Der)?,
+        ),
+    );
     attrs.insert(CKA_TRUSTED, Attr::CK_TRUE);
     attrs.insert(CKA_CERTIFICATE_TYPE, Attr::from_ck_cert_type(CKC_X_509));
     attrs.insert(CKA_CERTIFICATE_CATEGORY, Attr::from_ck_cert_category(0));
@@ -505,7 +514,7 @@ impl Object {
                     }
                 }
                 None => {
-                    rcode = cryptoki_sys::CKR_ATTRIBUTE_TYPE_INVALID;
+                    // rcode = cryptoki_sys::CKR_CRYPTOKI_ALREADY_INITIALIZED;
                     raw_attr.set_unavailable();
                 }
             };

--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -475,7 +475,7 @@ impl Session {
                 Ok(results)
             }
 
-            None => self.fetch_all_keys(requirements.kind),
+            None => self.fetch_all_keys(),
         }?;
 
         if let Some(kind) = requirements.kind {
@@ -485,10 +485,7 @@ impl Session {
         Ok(result.iter().map(|(handle, _)| *handle).collect())
     }
 
-    fn fetch_all_keys(
-        &mut self,
-        kind: Option<ObjectKind>,
-    ) -> Result<Vec<(CK_OBJECT_HANDLE, Object)>, Error> {
+    fn fetch_all_keys(&mut self) -> Result<Vec<(CK_OBJECT_HANDLE, Object)>, Error> {
         {
             let db = self.db.lock()?;
 
@@ -520,11 +517,11 @@ impl Session {
         let results: Result<Vec<_>, _> = if THREADS_ALLOWED.load(Ordering::Relaxed) {
             use rayon::prelude::*;
             keys.par_iter()
-                .map(|k| super::key::fetch_one(k, &self.db, &self.login_ctx, kind))
+                .map(|k| super::key::fetch_one(k, &self.db, &self.login_ctx, None))
                 .collect()
         } else {
             keys.iter()
-                .map(|k| super::key::fetch_one(k, &self.db, &self.login_ctx, kind))
+                .map(|k| super::key::fetch_one(k, &self.db, &self.login_ctx, None))
                 .collect()
         };
 


### PR DESCRIPTION
This PR contains 2 changes:

- Add the `CKA_SERIAL_NUMBER` attribute to certificate objects.
- Fix `fetch_all_keys` request caching a subset of all objects, using only the kind that  was first requested.

This doesn't fix the certificate upload part of #183, but that cannot be fixed without support for certificates without associated private keys.

This does fix certificate listing with `certutil` mentionned in #187.