### PR TITLE
Add `#[ignore]` for tests requiring network access

### DIFF
--- a/pkcs11/src/api/token.rs
+++ b/pkcs11/src/api/token.rs
@@ -428,7 +428,8 @@ mod tests {
 
     use super::*;
 
-    // ignored because it needs to be run alone on one thread
+    // Ignored by default because it would race with the other #[ignore] tests
+    // Run with cargo test -- --test-threads=1 --ignored
     #[test]
     #[ignore]
     fn test_wait_for_slot_event_no_event() {
@@ -441,7 +442,8 @@ mod tests {
         assert_eq!(result, cryptoki_sys::CKR_NO_EVENT);
     }
 
-    // ignored because it needs to be run alone on one thread
+    // Ignored by default because it would race with the other #[ignore] tests
+    // Run with cargo test -- --test-threads=1 --ignored
     #[test]
     #[ignore]
     fn test_wait_for_slot_event_one_event() {
@@ -460,7 +462,8 @@ mod tests {
         assert_eq!(slot, 0);
     }
 
-    // we ignore this test because it requires cargo test -- --test-threads=1
+    // Ignored by default because it would race with the other #[ignore] tests
+    // Run with cargo test -- --test-threads=1 --ignored
     #[test]
     #[ignore]
     fn test_wait_for_slot_event_blocking_one_event() {
@@ -483,7 +486,8 @@ mod tests {
         assert_eq!(slot, 0);
     }
 
-    // we ignore this test because it requires cargo test -- --test-threads=1
+    // Ignored by default because it would race with the other #[ignore] tests
+    // Run with cargo test -- --test-threads=1 --ignored
     #[test]
     #[ignore]
     fn test_wait_for_slot_event_blocking_finalize() {

--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -700,6 +700,8 @@ mod test {
 
     use super::*;
 
+    // Ignored by default due to network access
+    // Run with cargo test -- --test-threads=1 --ignored
     #[test]
     #[ignore]
     fn parrallel_fetch_all_keys() {
@@ -741,6 +743,8 @@ mod test {
         })
     }
 
+    // Ignored by default due to network access
+    // Run with cargo test -- --test-threads=1 --ignored
     #[test]
     #[ignore]
     fn parrallel_fetch_all_keys_fail() {

--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -701,6 +701,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[ignore]
     fn parrallel_fetch_all_keys() {
         init_for_tests();
         let slot = get_slot(0).unwrap();
@@ -741,6 +742,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn parrallel_fetch_all_keys_fail() {
         THREADS_ALLOWED.store(false, Ordering::Relaxed);
         init_for_tests();

--- a/pkcs11/src/config/config_file.rs
+++ b/pkcs11/src/config/config_file.rs
@@ -231,6 +231,8 @@ mod tests {
 
     use super::*;
 
+    // Ignored by default due ENV variable being changed for the duration of the tests
+    // Run with cargo test -- --test-threads=1 --ignored
     #[test]
     #[ignore]
     fn test_read_home_config() {
@@ -276,6 +278,8 @@ slots:
         fs::remove_dir_all(home).unwrap();
     }
 
+    // Ignored by default due ENV variable being changed for the duration of the tests
+    // Run with cargo test -- --test-threads=1 --ignored
     #[test]
     #[ignore]
     fn test_read_config_no_file() {


### PR DESCRIPTION
Fix #190 