### PR TITLE
Apache cert pkcs

### DIFF
--- a/container/apache/Dockerfile
+++ b/container/apache/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /rust/build/target/release/libnethsm_pkcs11.so /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so
-COPY _certificate.pem /certs/certificate.pem
 
 ADD container/apache/openssl.cnf /etc/ssl/openssl.cnf
 ADD container/apache/p11nethsm.conf /etc/nitrokey/p11nethsm.conf

--- a/container/apache/httpd.conf
+++ b/container/apache/httpd.conf
@@ -91,7 +91,7 @@ SSLRandomSeed connect builtin
 <VirtualHost *:8081>
       DocumentRoot /usr/local/apache2/htdocs
       SSLEngine on
-      SSLCertificateFile /certs/certificate.pem
+      SSLCertificateFile "pkcs11:object=webserver"
       SSLCertificateKeyFile "pkcs11:object=webserver"   
       ErrorLog /tmp/a-error.log
       CustomLog /tmp/a-access.log combined

--- a/container/nginx/openssl.cnf
+++ b/container/nginx/openssl.cnf
@@ -8,6 +8,6 @@ pkcs11 = pkcs11_section
 
 [pkcs11_section]
 engine_id = pkcs11
-dynamic_path = /usr/lib/x86_64-linux-gnu/engines-1.1/libpkcs11.so
+dynamic_path = /usr/lib/x86_64-linux-gnu/engines-3/pkcs11.so
 MODULE_PATH = /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so
 init = 0


### PR DESCRIPTION
Certificate doesn't need to be imported in Docker as it can be pulled directly by Apache from Nethsm.
Unfortunately I'm not able to do the same with Nginx.