### PR TITLE
Update release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu:22.04", "debian:12", "fedora:38", "alpine:3.18", "fedora:39"]
+        os: ["alpine:3.18", "debian:12", "fedora:39", "fedora:40", "ubuntu:22.04", "ubuntu:24.04"]
         rust-version: [stable]
 
     env:


### PR DESCRIPTION
This PR updates the release pipeline.

- Sorted the list alphabetically.
- Fedora 38 is EOL, replaced with Fedora 39 and 40.