### PR TITLE
Fix error throwing logic

### DIFF
--- a/pkcs11/src/backend/key.rs
+++ b/pkcs11/src/backend/key.rs
@@ -205,7 +205,7 @@ pub fn create_key_from_template(
 
     let key_class = if let Some(ref key_class) = parsed.key_class {
         let key_class = *key_class;
-        if key_class == ObjectKind::Other && key_class == ObjectKind::PublicKey {
+        if key_class == ObjectKind::Other || key_class == ObjectKind::PublicKey {
             return Err(Error::ObjectClassNotSupported);
         }
         key_class


### PR DESCRIPTION
the condition before throwing Error::ObjectClassNotSupported check if the key classequal other AND public key on the same time which doesn't make sense and doesn't work for either case, the logic should be OR.