### PR TITLE
Fix possible infinite loop when loading cert chains from Java P11KeyStore

### DIFF
--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -5,7 +5,7 @@ use std::{
 
 use cryptoki_sys::{
     CKR_OK, CK_FLAGS, CK_OBJECT_HANDLE, CK_RV, CK_SESSION_HANDLE, CK_SESSION_INFO, CK_SLOT_ID,
-    CK_USER_TYPE,
+    CK_USER_TYPE, CKA_SUBJECT,
 };
 use log::{debug, error, trace};
 use nethsm_sdk_rs::apis::default_api;
@@ -479,7 +479,20 @@ impl Session {
             .into_iter()
             .filter(|(_, obj)| {
                 if let Some(kind) = requirements.kind {
-                    kind == obj.kind
+                    // kind must match
+                    if kind != obj.kind {
+                        false
+                    // extra checks if kind is Cerificate
+                    } else if kind == ObjectKind::Certificate {
+                        // When Subject is provided as requirement, it must match
+                        requirements.cka_subject.is_none() ||
+                            obj.attr(CKA_SUBJECT)
+                                .map(|attr| attr.as_bytes())
+                                    == requirements.cka_subject.as_deref()
+                    // On other kinds, no need for extra checks
+                    } else {
+                        true
+                    }
                 } else {
                     true
                 }


### PR DESCRIPTION
When HSM contains certificate chains, the JDK P11KeyStore tries to load the full chain within loadChain() method.

This action is performed in a while(true) loop as:
```c
  while (true) {
    CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[] {
      ATTR_TOKEN_TRUE,
      ATTR_CLASS_CERT,
      new CK_ATTRIBUTE(CKA_SUBJECT,
          next.getIssuerX500Principal().getEncoded()) };
    long[] ch = findObjects(session, attrs);
    if (ch == null || ch.length == 0) {
        // done
        break;
    } else {
        // Just take the first
        next = loadCert(session, ch[0]);
        lChain.add(next);
        if (next.getSubjectX500Principal().equals
              (next.getIssuerX500Principal())) {
            // self signed
            break;
        }
    }
  }
```

Here, supporting filtering certificates by CKA_SUBJECT is crucial otherwise the while true loop would continue forever (until findObjects returns some certificates and first one is not self signed)