### PR TITLE
Rewrite networking to have proper round-robin across instances and retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -89,17 +89,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "hashbrown"
@@ -605,11 +605,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "ureq"
 version = "2.10.1"
-source = "git+https://github.com/Nitrokey/ureq.git?rev=dc716a0eb412db14ca75694ab7b99fb6f5d179f0#dc716a0eb412db14ca75694ab7b99fb6f5d179f0"
+source = "git+https://github.com/Nitrokey/ureq.git?rev=9ee324596cad8132d488721652dad7c37ed1987c#9ee324596cad8132d488721652dad7c37ed1987c"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ panic = 'abort'     # Abort on panic
 strip = true        # Strip symbols from binary
 
 [patch.crates-io]
-ureq =  { git = "https://github.com/Nitrokey/ureq.git", rev = "dc716a0eb412db14ca75694ab7b99fb6f5d179f0" }
+ureq =  { git = "https://github.com/Nitrokey/ureq.git", rev = "9ee324596cad8132d488721652dad7c37ed1987c" }

--- a/pkcs11/Cargo.toml
+++ b/pkcs11/Cargo.toml
@@ -50,7 +50,7 @@ pkcs11 = "0.5.0"
 tempfile = "3.12.0"
 test-log = "0.2.16"
 time = "0.3.36"
-tokio = {version = "1", default-features = false, features = ["net", "sync", "rt", "io-util"] }
+tokio = {version = "1", default-features = false, features = ["net", "sync", "rt", "io-util", "time"] }
 
 [features]
 pkcs11-full-tests = []

--- a/pkcs11/src/api/generation.rs
+++ b/pkcs11/src/api/generation.rs
@@ -8,7 +8,7 @@ use crate::{
         db::attr::CkRawAttrTemplate,
         mechanism::{CkRawMechanism, Mechanism},
     },
-    lock_session, read_session,
+    read_session,
 };
 
 pub extern "C" fn C_GenerateKey(
@@ -232,7 +232,7 @@ pub extern "C" fn C_GenerateRandom(
 
         return cryptoki_sys::CKR_ARGUMENTS_BAD;
     }
-    lock_session!(hSession, session);
+    read_session!(hSession, session);
 
     if !session
         .login_ctx

--- a/pkcs11/src/api/object.rs
+++ b/pkcs11/src/api/object.rs
@@ -276,9 +276,8 @@ mod tests {
             db::{Db, Object},
             login::LoginCtx,
             session::Session,
-            slot::init_for_tests,
+            slot::{get_slot, init_for_tests},
         },
-        config::config_file::RetryConfig,
         data::SESSION_MANAGER,
     };
 
@@ -399,6 +398,7 @@ mod tests {
     #[test]
     fn test_get_object_size() {
         init_for_tests();
+        let slot = get_slot(0).unwrap();
         let size = 32;
         let mut db = Db::new();
         let mut object = Object::default();
@@ -414,15 +414,7 @@ mod tests {
             device_error: 0,
             enum_ctx: None,
             flags: 0,
-            login_ctx: LoginCtx::new(
-                None,
-                None,
-                vec![],
-                Some(RetryConfig {
-                    count: 2,
-                    delay_seconds: 0,
-                }),
-            ),
+            login_ctx: LoginCtx::new(slot, false, false),
             slot_id: 0,
         };
 

--- a/pkcs11/src/api/token.rs
+++ b/pkcs11/src/api/token.rs
@@ -92,7 +92,7 @@ pub extern "C" fn C_GetSlotInfo(
 
     let mut flags = 0;
 
-    let mut login_ctx = LoginCtx::new(None, None, slot.instances.clone(), slot.retries);
+    let login_ctx = LoginCtx::new(slot.clone(), false, false);
 
     let result = login_ctx.try_(
         default_api::info_get,
@@ -166,12 +166,7 @@ pub extern "C" fn C_GetTokenInfo(
         return cryptoki_sys::CKR_ARGUMENTS_BAD;
     }
 
-    let mut login_ctx = LoginCtx::new(
-        None,
-        slot.administrator.clone(),
-        slot.instances.clone(),
-        slot.retries,
-    );
+    let login_ctx = LoginCtx::new(slot.clone(), true, false);
 
     let result = login_ctx.try_(
         default_api::info_get,

--- a/pkcs11/src/backend/encrypt.rs
+++ b/pkcs11/src/backend/encrypt.rs
@@ -101,7 +101,7 @@ impl EncryptCtx {
 
 fn encrypt_data(
     key_id: &str,
-    mut login_ctx: LoginCtx,
+    login_ctx: LoginCtx,
     data: &[u8],
     mechanism: &Mechanism,
 ) -> Result<Vec<u8>, Error> {
@@ -134,7 +134,7 @@ fn encrypt_data(
             login::UserMode::Operator,
         )
         .map_err(|err| {
-            if let ApiError::ResponseError(ref resp) = err {
+            if let Error::Api(ApiError::ResponseError(ref resp)) = err {
                 if resp.status == 400 {
                     if resp.content.contains("argument length") {
                         return Error::InvalidDataLength;
@@ -142,7 +142,7 @@ fn encrypt_data(
                     return Error::InvalidData;
                 }
             }
-            err.into()
+            err
         })?;
 
     Ok(Base64::decode_vec(&output.entity.encrypted)?)

--- a/pkcs11/src/backend/events.rs
+++ b/pkcs11/src/backend/events.rs
@@ -42,7 +42,7 @@ pub fn fetch_slots_state() -> Result<(), cryptoki_sys::CK_RV> {
     };
 
     for (index, slot) in device.slots.iter().enumerate() {
-        let mut login_ctx = LoginCtx::new(None, None, slot.instances.clone(), slot.retries);
+        let login_ctx = LoginCtx::new(slot.clone(), false, false);
         let status = login_ctx
             .try_(default_api::health_state_get, super::login::UserMode::Guest)
             .map(|state| state.entity.state == SystemState::Operational)

--- a/pkcs11/src/backend/key.rs
+++ b/pkcs11/src/backend/key.rs
@@ -154,7 +154,7 @@ pub fn parse_attributes(template: &CkRawAttrTemplate) -> Result<ParsedAttributes
 
 fn upload_certificate(
     parsed_template: &ParsedAttributes,
-    mut login_ctx: LoginCtx,
+    login_ctx: LoginCtx,
 ) -> Result<(String, ObjectKind, Option<Vec<u8>>), Error> {
     let cert = parsed_template
         .value
@@ -196,7 +196,7 @@ fn upload_certificate(
 
 pub fn create_key_from_template(
     template: CkRawAttrTemplate,
-    mut login_ctx: LoginCtx,
+    login_ctx: LoginCtx,
 ) -> Result<(String, ObjectKind, Option<Vec<u8>>), Error> {
     let parsed = parse_attributes(&template)?;
 
@@ -415,7 +415,7 @@ pub fn generate_key_from_template(
     template: &CkRawAttrTemplate,
     public_template: Option<&CkRawAttrTemplate>,
     mechanism: &Mechanism,
-    mut login_ctx: LoginCtx,
+    login_ctx: LoginCtx,
     db: &Mutex<db::Db>,
 ) -> Result<Vec<(CK_OBJECT_HANDLE, Object)>, Error> {
     let parsed = parse_attributes(template)?;
@@ -462,7 +462,7 @@ pub fn generate_key_from_template(
 fn fetch_one_key(
     key_id: &str,
     raw_id: Option<Vec<u8>>,
-    mut login_ctx: LoginCtx,
+    login_ctx: LoginCtx,
 ) -> Result<Vec<Object>, Error> {
     if !login_ctx.can_run_mode(super::login::UserMode::OperatorOrAdministrator) {
         return Err(Error::NotLoggedIn(
@@ -479,11 +479,14 @@ fn fetch_one_key(
             debug!("Failed to fetch key {}: {:?}", key_id, err);
             if matches!(
                 err,
-                ApiError::ResponseError(backend::ResponseContent { status: 404, .. })
+                Error::Api(ApiError::ResponseError(backend::ResponseContent {
+                    status: 404,
+                    ..
+                }))
             ) {
                 return Ok(vec![]);
             }
-            return Err(err.into());
+            return Err(err);
         }
     };
 
@@ -509,7 +512,7 @@ pub fn fetch_key(
 fn fetch_one_certificate(
     key_id: &str,
     raw_id: Option<Vec<u8>>,
-    mut login_ctx: LoginCtx,
+    login_ctx: LoginCtx,
 ) -> Result<Object, Error> {
     if !login_ctx.can_run_mode(super::login::UserMode::OperatorOrAdministrator) {
         return Err(Error::NotLoggedIn(

--- a/pkcs11/src/backend/key.rs
+++ b/pkcs11/src/backend/key.rs
@@ -154,7 +154,7 @@ pub fn parse_attributes(template: &CkRawAttrTemplate) -> Result<ParsedAttributes
 
 fn upload_certificate(
     parsed_template: &ParsedAttributes,
-    login_ctx: LoginCtx,
+    login_ctx: &LoginCtx,
 ) -> Result<(String, ObjectKind, Option<Vec<u8>>), Error> {
     let cert = parsed_template
         .value
@@ -196,7 +196,7 @@ fn upload_certificate(
 
 pub fn create_key_from_template(
     template: CkRawAttrTemplate,
-    login_ctx: LoginCtx,
+    login_ctx: &LoginCtx,
 ) -> Result<(String, ObjectKind, Option<Vec<u8>>), Error> {
     let parsed = parse_attributes(&template)?;
 
@@ -415,7 +415,7 @@ pub fn generate_key_from_template(
     template: &CkRawAttrTemplate,
     public_template: Option<&CkRawAttrTemplate>,
     mechanism: &Mechanism,
-    login_ctx: LoginCtx,
+    login_ctx: &LoginCtx,
     db: &Mutex<db::Db>,
 ) -> Result<Vec<(CK_OBJECT_HANDLE, Object)>, Error> {
     let parsed = parse_attributes(template)?;
@@ -462,7 +462,7 @@ pub fn generate_key_from_template(
 fn fetch_one_key(
     key_id: &str,
     raw_id: Option<Vec<u8>>,
-    login_ctx: LoginCtx,
+    login_ctx: &LoginCtx,
 ) -> Result<Vec<Object>, Error> {
     if !login_ctx.can_run_mode(super::login::UserMode::OperatorOrAdministrator) {
         return Err(Error::NotLoggedIn(
@@ -499,7 +499,7 @@ fn fetch_one_key(
 pub fn fetch_key(
     key_id: &str,
     raw_id: Option<Vec<u8>>,
-    login_ctx: LoginCtx,
+    login_ctx: &LoginCtx,
     db: &Mutex<db::Db>,
 ) -> Result<Vec<(CK_OBJECT_HANDLE, Object)>, Error> {
     let objects = fetch_one_key(key_id, raw_id, login_ctx)?;
@@ -512,7 +512,7 @@ pub fn fetch_key(
 fn fetch_one_certificate(
     key_id: &str,
     raw_id: Option<Vec<u8>>,
-    login_ctx: LoginCtx,
+    login_ctx: &LoginCtx,
 ) -> Result<Object, Error> {
     if !login_ctx.can_run_mode(super::login::UserMode::OperatorOrAdministrator) {
         return Err(Error::NotLoggedIn(
@@ -533,7 +533,7 @@ fn fetch_one_certificate(
 pub fn fetch_certificate(
     key_id: &str,
     raw_id: Option<Vec<u8>>,
-    login_ctx: LoginCtx,
+    login_ctx: &LoginCtx,
     db: &Mutex<db::Db>,
 ) -> Result<(CK_OBJECT_HANDLE, Object), Error> {
     let object = fetch_one_certificate(key_id, raw_id, login_ctx)?;
@@ -571,12 +571,10 @@ pub fn fetch_one(
             | Some(ObjectKind::PublicKey)
             | Some(ObjectKind::SecretKey)
     ) {
-        let login_ctx = login_ctx.clone();
         acc = fetch_one_key(&key.id, None, login_ctx)?;
     }
 
     if matches!(kind, None | Some(ObjectKind::Certificate)) {
-        let login_ctx = login_ctx.clone();
         match fetch_one_certificate(&key.id, None, login_ctx) {
             Ok(cert) => acc.push(cert),
             Err(err) => {

--- a/pkcs11/src/backend/login.rs
+++ b/pkcs11/src/backend/login.rs
@@ -249,14 +249,14 @@ impl LoginCtx {
             count: retry_limit,
             delay_seconds,
         } = self.slot.retries.unwrap_or(RetryConfig {
-            count: 1,
+            count: 0,
             delay_seconds: 0,
         });
 
         let delay = Duration::from_secs(delay_seconds);
 
         loop {
-            if retry_count == retry_limit {
+            if retry_count > retry_limit {
                 error!(
                     "Retry count exceeded after {retry_limit} attempts, instance is unreachable"
                 );
@@ -292,6 +292,7 @@ impl LoginCtx {
                         ureq::ErrorKind::Io | ureq::ErrorKind::ConnectionFailed
                     ) =>
                 {
+                    self.slot.clear_all_pools();
                     instance.bump_failed();
                     warn!("Connection attempt {retry_count} failed: IO error connecting to the instance, {err}, retrying in {delay_seconds}s");
                     thread::sleep(delay);

--- a/pkcs11/src/backend/login.rs
+++ b/pkcs11/src/backend/login.rs
@@ -22,7 +22,7 @@ use crate::config::{
 
 use super::{ApiError, Error};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LoginCtx {
     slot: Arc<Slot>,
     /// If set to `Some`, this will be used to replace the slot's default value when performing requests

--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -732,7 +732,7 @@ mod test {
                 delay_seconds: 0,
             });
             let bad_instance = &mut slot_mut.instances[0];
-            bad_instance.base_path.push_str("/corrupted_url");
+            bad_instance.config.base_path.push_str("/corrupted_url");
             let session = Session {
                 db: slot_mut.db.clone(),
                 decrypt_ctx: None,

--- a/pkcs11/src/backend/sign.rs
+++ b/pkcs11/src/backend/sign.rs
@@ -102,7 +102,7 @@ impl SignCtx {
         let mode = self.sign_name;
         trace!("Signing with mode: {:?}", mode);
 
-        let mut login_ctx = self.login_ctx.clone();
+        let login_ctx = self.login_ctx.clone();
 
         let signature = login_ctx.try_(
             |conf| {

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -208,4 +208,10 @@ impl Slot {
 
         !pwd.is_empty()
     }
+
+    pub fn clear_all_pools(&self) {
+        for instance in &self.instances {
+            instance.config.client.clear_pool();
+        }
+    }
 }

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -1,13 +1,75 @@
 use std::{
-    sync::{atomic::AtomicUsize, Arc, Condvar, Mutex, RwLock},
-    time::Instant,
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering::Relaxed},
+        mpsc::{self, RecvTimeoutError},
+        Arc, Condvar, LazyLock, Mutex, RwLock,
+    },
+    thread,
+    time::{Duration, Instant},
 };
 
-use nethsm_sdk_rs::apis::configuration::Configuration;
+use nethsm_sdk_rs::apis::{configuration::Configuration, default_api::health_ready_get};
 
-use crate::backend::db::Db;
+use crate::{backend::db::Db, data::THREADS_ALLOWED};
 
 use super::config_file::{RetryConfig, UserConfig};
+
+static RETRY_THREAD: LazyLock<mpsc::Sender<(Duration, InstanceData)>> = LazyLock::new(|| {
+    let (tx, rx) = mpsc::channel();
+    let (tx_instance, rx_instance) = mpsc::channel();
+    thread::spawn(background_thread(rx_instance));
+    thread::spawn(background_timer(rx, tx_instance));
+    tx
+});
+
+fn background_timer(
+    rx: mpsc::Receiver<(Duration, InstanceData)>,
+    tx_instance: mpsc::Sender<InstanceData>,
+) -> impl FnOnce() {
+    let mut jobs: BTreeMap<Instant, InstanceData> = BTreeMap::new();
+    move || loop {
+        let next_job = jobs.pop_first();
+        let Some((next_job_deadline, next_job_instance)) = next_job else {
+            // No jobs in the queue, we can just run the next
+            let Ok((new_job_duration, new_state)) = rx.recv() else {
+                return;
+            };
+
+            jobs.insert(Instant::now() + new_job_duration, new_state);
+            continue;
+        };
+
+        let now = Instant::now();
+
+        if now >= next_job_deadline {
+            tx_instance.send(next_job_instance).unwrap();
+            continue;
+        }
+        jobs.insert(next_job_deadline, next_job_instance);
+
+        let timeout = next_job_deadline.duration_since(now);
+        match rx.recv_timeout(timeout) {
+            Ok((run_in, new_instance)) => {
+                jobs.insert(now + run_in, new_instance);
+                continue;
+            }
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+    }
+}
+
+fn background_thread(rx: mpsc::Receiver<InstanceData>) -> impl FnOnce() {
+    move || loop {
+        while let Ok(instance) = rx.recv() {
+            match health_ready_get(&instance.config) {
+                Ok(_) => instance.clear_failed(),
+                Err(_) => instance.bump_failed(),
+            }
+        }
+    }
+}
 
 // stores the global configuration of the module
 #[derive(Debug, Clone)]
@@ -16,20 +78,108 @@ pub struct Device {
     pub enable_set_attribute_value: bool,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum InstanceState {
     #[default]
     Working,
     Failed {
-        retry_count: usize,
+        retry_count: u8,
         last_retry_at: Instant,
     },
+}
+
+impl InstanceState {
+    pub fn new_failed() -> InstanceState {
+        InstanceState::Failed {
+            retry_count: 0,
+            last_retry_at: Instant::now(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct InstanceData {
     pub config: Configuration,
     pub state: Arc<RwLock<InstanceState>>,
+}
+
+pub enum InstanceAttempt {
+    /// The instance is in the failed state and should not be used
+    Failed,
+    /// The instance is in the failed  state but a connection should be attempted
+    Retry,
+    /// The instance is in the working state
+    Working,
+}
+
+impl InstanceData {
+    pub fn should_try(&self) -> InstanceAttempt {
+        let this = self.state.read().unwrap();
+        match *this {
+            InstanceState::Working => InstanceAttempt::Working,
+            InstanceState::Failed {
+                retry_count,
+                last_retry_at,
+            } => {
+                if last_retry_at.elapsed() < retry_duration_from_count(retry_count) {
+                    InstanceAttempt::Failed
+                } else {
+                    InstanceAttempt::Retry
+                }
+            }
+        }
+    }
+
+    pub fn clear_failed(&self) {
+        *self.state.write().unwrap() = InstanceState::Working;
+    }
+
+    pub fn bump_failed(&self) {
+        let mut write = self.state.write().unwrap();
+        let retry_count = match *write {
+            InstanceState::Working => {
+                *write = InstanceState::new_failed();
+                0
+            }
+            InstanceState::Failed {
+                retry_count: prev_retry_count,
+                last_retry_at,
+            } => {
+                // We only bump if it's a "real" retry. This is to avoid race conditions where
+                // the same instance stops working when multiple threads are simultaneously connecting
+                // to it
+                if last_retry_at.elapsed() >= retry_duration_from_count(prev_retry_count) {
+                    let retry_count = prev_retry_count.saturating_add(1);
+                    *write = InstanceState::Failed {
+                        retry_count,
+                        last_retry_at: Instant::now(),
+                    };
+                    retry_count
+                } else {
+                    prev_retry_count
+                }
+            }
+        };
+        drop(write);
+        if THREADS_ALLOWED.load(Relaxed) {
+            RETRY_THREAD
+                .send((retry_duration_from_count(retry_count), self.clone()))
+                .ok();
+        }
+    }
+}
+
+fn retry_duration_from_count(retry_count: u8) -> Duration {
+    let secs = match retry_count {
+        0 | 1 => 1,
+        2 => 2,
+        3 => 5,
+        4 => 10,
+        5 => 60,
+        6.. => 60 * 5,
+    };
+
+    Duration::from_secs(secs)
 }
 
 #[derive(Debug, Clone)]

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{atomic::AtomicUsize, Arc, Condvar, Mutex};
 
 use nethsm_sdk_rs::apis::configuration::Configuration;
 
@@ -22,6 +22,7 @@ pub struct Slot {
     pub operator: Option<UserConfig>,
     pub administrator: Option<UserConfig>,
     pub db: Arc<(Mutex<Db>, Condvar)>,
+    pub instance_balancer: Arc<AtomicUsize>,
 }
 
 impl Slot {

--- a/pkcs11/src/config/initialization.rs
+++ b/pkcs11/src/config/initialization.rs
@@ -5,6 +5,8 @@ use std::{
     time::Duration,
 };
 
+use crate::config::device::InstanceData;
+
 use super::{
     config_file::{config_files, ConfigError, SlotConfig},
     device::{Device, Slot},
@@ -283,7 +285,10 @@ fn slot_from_config(slot: &SlotConfig) -> Result<Slot, InitializationError> {
             user_agent: Some(DEFAULT_USER_AGENT.to_string()),
             ..Default::default()
         };
-        instances.push(api_config);
+        instances.push(InstanceData {
+            config: api_config,
+            state: Default::default(),
+        });
     }
     if instances.is_empty() {
         error!("Slot without any instance configured");


### PR DESCRIPTION
This PR:

- Adds state for each instance in a slot. This state stores information on whether the instance is is a "failed" state or not
- On failure (IO or 5xx or 412), mark the instance as failed
- When an instance is marked as failed and threads are allowed, spawn a background thread to retry it with some backoff.
- Don't use failed instances
- If all instances are failed, try failed instances anyway (this will especially happen in the case where spawning threads is not allowed).
- On IO failure, remove all the idle connections


Depends on:

- https://github.com/Nitrokey/ureq/pull/4
- #214 
