### PR TITLE
Implement short retries in single threaded context

### DIFF
--- a/pkcs11/src/backend/login.rs
+++ b/pkcs11/src/backend/login.rs
@@ -90,6 +90,7 @@ impl std::fmt::Display for LoginError {
 
 /// Perform a health check with a timeout of 1 second
 fn health_check_get_timeout(instance: &InstanceData) -> bool {
+    instance.config.client.clear_pool();
     let config = &instance.config;
     let uri_str = format!("{}/health/ready", config.base_path);
     let mut req = config.client.get(&uri_str).timeout(Duration::from_secs(1));

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -82,6 +82,7 @@ fn background_timer(
 fn background_thread(rx: mpsc::Receiver<InstanceData>) -> impl FnOnce() {
     move || loop {
         while let Ok(instance) = rx.recv() {
+            instance.config.client.clear_pool();
             match health_ready_get(&instance.config) {
                 Ok(_) => instance.clear_failed(),
                 Err(_) => instance.bump_failed(),


### PR DESCRIPTION
Also, fix round retry mechanism not being used for login This two are merged because the changing of the `next_instance` signature showed that `login()` did not use the retry mechanism.

This does not count in the timeout calculation for each requests, so requests are limited to perform up to 3 health check at most (each with 1s timeout, so 3 seconds total).

This also makes all tests run both in single-threaded an multi-threaded modes.

This also removes some memory leaks in tests and in the `Finalize` call (the background thread did not close the instances it had.