### PR TITLE
Add support for DER-encoded certificates

### DIFF
--- a/p11nethsm.example.conf
+++ b/p11nethsm.example.conf
@@ -57,6 +57,13 @@ slots:
         # Alternatively certificate checks can be skipped entirely with danger_insecure_cert option.
         # This should be avoided if possible and certainly not used with a productive NetHSM.
         # danger_insecure_cert: true
+    # Configure whether the certificates stored in the nethsm are stored in PEM or DER
+    # The nethsm itself supports both, but some tooling may only support one of the encodings.
+    # Valid values are PEM or DER. Defaults to PEM
+    #
+    # Values exchanged over the PKCS#11 interface will always be DER encoded.
+    # This config only changes the format they are stored in on the Nethsm itself for compatibility with other tooling.
+    certificate_format: PEM
     # Configure the network retry mechanism. If absent, no retries are attempted on a network error
     retries:
       # The number of retries after a network error

--- a/pkcs11/config_file/src/lib.rs
+++ b/pkcs11/config_file/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{io::Read, mem, net::SocketAddr, path::PathBuf};
+use std::{fmt::Display, io::Read, mem, net::SocketAddr, path::PathBuf};
 
 use merge::Merge;
 use serde::{Deserialize, Serialize};
@@ -179,6 +179,23 @@ impl<'de> Deserialize<'de> for HexFingerprint {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Copy)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum CertificateFormat {
+    #[default]
+    Pem,
+    Der,
+}
+
+impl Display for CertificateFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pem => f.write_str("PEM"),
+            Self::Der => f.write_str("DER"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InstanceConfig {
     pub url: String,
@@ -205,6 +222,8 @@ pub struct SlotConfig {
     pub timeout_seconds: Option<u64>,
     #[serde(default)]
     pub connections_max_idle_duration: Option<u64>,
+    #[serde(default)]
+    pub certificate_format: CertificateFormat,
 }
 
 // An user
@@ -398,7 +417,8 @@ password: ""
                         interval_seconds: 60,
                         retries: 3
                     }),
-                    connections_max_idle_duration: Some(60 * 30)
+                    connections_max_idle_duration: Some(60 * 30),
+                    certificate_format: CertificateFormat::Pem,
                 }]
             },
             serde_yaml::from_str(config).unwrap()

--- a/pkcs11/src/backend/login.rs
+++ b/pkcs11/src/backend/login.rs
@@ -149,6 +149,10 @@ impl LoginCtx {
         }
     }
 
+    pub fn slot(&self) -> &Arc<Slot> {
+        &self.slot
+    }
+
     fn operator_config(&self) -> Option<&UserConfig> {
         if !self.operator_allowed {
             return None;

--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -99,6 +99,7 @@ impl SessionManager {
                 label: "test".to_string(),
                 operator: None,
                 instance_balancer: Default::default(),
+                certificate_format: config_file::CertificateFormat::Der,
             }),
             0,
         )

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
+use config_file::CertificateFormat;
 use nethsm_sdk_rs::apis::{configuration::Configuration, default_api::health_ready_get};
 use ureq::unversioned::{
     resolver::{DefaultResolver, Resolver},
@@ -324,6 +325,7 @@ pub struct Slot {
     pub administrator: Option<UserConfig>,
     pub db: Arc<(Mutex<Db>, Condvar)>,
     pub instance_balancer: Arc<AtomicUsize>,
+    pub certificate_format: CertificateFormat,
 }
 
 impl Slot {

--- a/pkcs11/src/config/initialization.rs
+++ b/pkcs11/src/config/initialization.rs
@@ -330,12 +330,15 @@ fn slot_from_config(slot: &SlotConfig) -> Result<Slot, InitializationError> {
         retries: slot.retries,
         db: Arc::new((Mutex::new(crate::backend::db::Db::new()), Condvar::new())),
         instance_balancer: Default::default(),
+        certificate_format: slot.certificate_format,
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use config_file::CertificateFormat;
 
     /// Test various good and bad configs for panics
     #[test]
@@ -355,6 +358,7 @@ slots:
         danger_insecure_cert: true  
         sha256_fingerprints: 
           - "31:92:8E:A4:5E:16:5C:A7:33:44:E8:E9:8E:64:C4:AE:7B:2A:57:E5:77:43:49:F3:69:C9:8F:C4:2F:3A:3B:6E"
+    certificate_format: DER
     retries: 
       count: 10
       delay_seconds: 1
@@ -363,7 +367,8 @@ slots:
         let config_path = "/path/to/config.conf";
         let configs = vec![(config_content.into(), config_path.into())];
 
-        assert!(initialize_with_configs(Ok(configs)).is_ok());
+        let device = initialize_with_configs(Ok(configs)).unwrap();
+        assert_eq!(device.slots[0].certificate_format, CertificateFormat::Der);
 
         let config_bad_fingerprint_content = r#"
 slots:

--- a/pkcs11/tests/basic.rs
+++ b/pkcs11/tests/basic.rs
@@ -6,7 +6,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use config_file::{InstanceConfig, P11Config, RetryConfig, SlotConfig, UserConfig};
+use config_file::{
+    CertificateFormat, InstanceConfig, P11Config, RetryConfig, SlotConfig, UserConfig,
+};
 use pkcs11::types::{
     CKA_MODULUS_BITS, CKA_PUBLIC_EXPONENT, CKA_SIGN, CKA_TOKEN, CKA_VERIFY, CKM_RSA_PKCS,
     CK_ATTRIBUTE, CK_BBOOL, CK_FALSE, CK_MECHANISM, CK_TRUE, CK_ULONG,
@@ -79,6 +81,7 @@ fn basic() {
                     sha256_fingerprints: Vec::new(),
                     max_idle_connections: None,
                 }],
+                certificate_format: CertificateFormat::Pem,
                 retries: None,
                 timeout_seconds: Some(10),
                 connections_max_idle_duration: None,
@@ -138,6 +141,7 @@ fn multiple_instances() {
                         max_idle_connections: None,
                     },
                 ],
+                certificate_format: CertificateFormat::Pem,
                 retries: None,
                 timeout_seconds: Some(10),
                 connections_max_idle_duration: None,
@@ -191,6 +195,7 @@ fn timeout() {
                     sha256_fingerprints: Vec::new(),
                     max_idle_connections: None,
                 }],
+                certificate_format: CertificateFormat::Pem,
                 retries: None,
                 timeout_seconds: Some(10),
                 connections_max_idle_duration: None,
@@ -253,6 +258,7 @@ fn retries() {
                     sha256_fingerprints: Vec::new(),
                     max_idle_connections: None,
                 }],
+                certificate_format: CertificateFormat::Pem,
                 retries: Some(RetryConfig {
                     count: 2,
                     delay_seconds: 2,
@@ -332,6 +338,7 @@ fn multi_instance_retries() {
                         max_idle_connections: None,
                     },
                 ],
+                certificate_format: CertificateFormat::Pem,
                 retries: Some(RetryConfig {
                     count: 3,
                     delay_seconds: 1,
@@ -403,6 +410,7 @@ fn pool_not_reused() {
                         max_idle_connections: None,
                     },
                 ],
+                certificate_format: CertificateFormat::Pem,
                 retries: None,
                 timeout_seconds: Some(5),
                 connections_max_idle_duration: None,

--- a/tools/der_cert.conf
+++ b/tools/der_cert.conf
@@ -1,0 +1,23 @@
+# log_file: /tmp/p11nethsm.log
+# log_level: Trace
+# enable_set_attribute_value: false
+slots:
+  - label: LocalHSM
+    description: Local HSM (docker)
+    operator:
+      username: "operator"
+      password: "opPassphrase"
+    administrator:
+      username: "admin"
+      password: "Administrator"
+    instances:
+      - url: "https://localhost:8443/api/v1"
+        max_idle_connections: 16
+        danger_insecure_cert: true  
+        # sha256_fingerprints: 
+          # - "31:92:8E:A4:5E:16:5C:A7:33:44:E8:E9:8E:64:C4:AE:7B:2A:57:E5:77:43:49:F3:69:C9:8F:C4:2F:3A:3B:6E"
+    certificate_format: DER
+    retries: 
+      count: 10
+      delay_seconds: 1
+    timeout_seconds: 10

--- a/tools/tests/upload_der_certificate.sh
+++ b/tools/tests/upload_der_certificate.sh
@@ -1,0 +1,31 @@
+#!/bin/sh -x
+
+set -e 
+
+rm -rf _cert.key _cert.der _curl_cert.der
+
+export P11NETHSM_CONFIG_FILE=./tools/der_cert.conf
+
+KEYID=certtest
+
+HEXID=$(echo -n ${KEYID}| xxd -ps)
+
+
+curl -k -u admin:Administrator -v -X DELETE \
+  https://localhost:8443/api/v1/keys/$KEYID
+
+openssl req -x509 -newkey rsa:2048 -keyout _cert.key -out _cert.der -outform DER -days 365 -nodes -subj "/CN=www.example.com"
+openssl x509 -in _cert.der -out _cert.pem -inform DER -outform PEM
+
+p11tool --provider ${PWD}/target/debug/libnethsm_pkcs11.so --write  --id $HEXID --label $KEYID --load-privkey _cert.key
+p11tool --provider ${PWD}/target/debug/libnethsm_pkcs11.so --write  --id $HEXID --label $KEYID --load-certificate _cert.pem
+
+p11tool --provider ${PWD}/target/debug/libnethsm_pkcs11.so --write  --id $HEXID --label $KEYID --list-cert |grep 'Type: X.509 Certificate'
+
+
+# check if the cert is there
+curl -k --fail-with-body -u operator:opPassphrase -v -X GET \
+  https://localhost:8443/api/v1/keys/$KEYID/cert --header "Accept: application/octet-stream" -o _curl_cert.der
+
+diff _cert.der _curl_cert.der
+


### PR DESCRIPTION
This is made through a config flag, since it is not possible to distinguish a valid DER encoded file from a PEM encoded file (a file can be valid as both)