### PR TITLE
Cleanup background threads when finalizing

### DIFF
--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -109,7 +109,7 @@ fn background_timer(
 }
 
 fn background_thread(rx: mpsc::Receiver<InstanceData>) -> impl FnOnce() {
-    move || loop {
+    move || {
         while let Ok(instance) = rx.recv() {
             instance.clear_pool();
             match health_ready_get(&instance.config) {

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::BTreeMap,
-    mem,
     sync::{
         atomic::AtomicUsize,
         mpsc::{self, RecvError, RecvTimeoutError},
@@ -53,7 +52,7 @@ pub fn start_background_timer() {
 }
 
 pub fn stop_background_timer() {
-    let res = mem::take(&mut *RETRY_THREAD.write().unwrap());
+    let res = RETRY_THREAD.write().unwrap().take();
     let Some(RetryChannel {
         tx,
         background_thread,

--- a/pkcs11/src/config/device.rs
+++ b/pkcs11/src/config/device.rs
@@ -62,8 +62,30 @@ pub fn stop_background_timer() {
         return;
     };
     drop(tx);
-    background_thread.join().unwrap();
-    background_timer.join().unwrap();
+    background_thread
+        .join()
+        .inspect_err(|err| {
+            if let Some(err) = err.downcast_ref::<&'static str>() {
+                log::error!("Background thread panicked: {err}");
+            } else if let Some(err) = err.downcast_ref::<String>() {
+                log::error!("Background thread panicked: {err}");
+            } else {
+                log::error!("Background thread panicked: {err:?}");
+            }
+        })
+        .ok();
+    background_timer
+        .join()
+        .inspect_err(|err| {
+            if let Some(err) = err.downcast_ref::<&'static str>() {
+                log::error!("Background timer panicked: {err}");
+            } else if let Some(err) = err.downcast_ref::<String>() {
+                log::error!("Background timer panicked: {err}");
+            } else {
+                log::error!("Background timer panicked: {err:?}");
+            }
+        })
+        .ok();
 }
 
 fn background_timer(


### PR DESCRIPTION
Previously we only cleaned up their work, but we need to actually kill the threads, so that unloading the library does not leave the background threads in a weird state.  Notably this should make sure that `thread_local` stuff for those threads is properly disposed of.

Fix #237 (This fixed reproduction in a VM, waiting for confirmation from the original reporter that the bug is fully gone).