### PR TITLE
Fix macos CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable-x86_64-apple-darwin
-          target: aarch64-apple-darwin
+        run: rustup install stable && rustup target install aarch64-apple-darwin && rustup target install x86_64-apple-darwin
 
       - uses: Swatinem/rust-cache@v2
 
@@ -56,10 +52,10 @@ jobs:
         run: cargo build --release --target aarch64-apple-darwin
 
       - name: Build project
-        run: cargo build --release
+        run: cargo build --release --target x86_64-apple-darwin
 
       - name: rename file
-        run: mv target/release/libnethsm_pkcs11.dylib ${{ env.FILE_NAME }}
+        run: mv target/x86_64-apple-darwin/release/libnethsm_pkcs11.dylib ${{ env.FILE_NAME }}
       - name: rename file arm
         run: mv target/aarch64-apple-darwin/release/libnethsm_pkcs11.dylib ${{ env.FILE_NAME_ARM }}
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -70,26 +70,22 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable-x86_64-apple-darwin
-          target: aarch64-apple-darwin
+        run: rustup install stable && rustup target install aarch64-apple-darwin && rustup target install x86_64-apple-darwin
 
       - uses: Swatinem/rust-cache@v2
 
       - name: Build project for MacOs x86_64
-        run: cargo build --release
+        run: cargo build --release --target x86_64-apple-darwin
 
       - name: Archive Artifact x86_64
         uses: actions/upload-artifact@v4
         with:
           name: nethsm-pkcs11-x86_64-apple.dylib
-          path: target/release/libnethsm_pkcs11.dylib
+          path: target/x86_64-apple-darwin/release/libnethsm_pkcs11.dylib
           if-no-files-found: error
 
       - name: Build project MacOs aaarch64
-        run: cargo build --target aarch64-apple-darwin --release
+        run: cargo build --release --target aarch64-apple-darwin
 
       - name: Archive Artifact
         uses: actions/upload-artifact@v4

--- a/pkcs11/src/backend/key.rs
+++ b/pkcs11/src/backend/key.rs
@@ -562,7 +562,7 @@ fn extract_key_id_location_header(headers: HashMap<String, String>) -> Result<St
     let location_header = headers.get("location").ok_or(Error::InvalidData)?;
     let key_id = location_header
         .split('/')
-        .last()
+        .next_back()
         .ok_or(Error::InvalidData)?
         .split('?')
         .next()


### PR DESCRIPTION
- Fix clippy warning coming from rust 1.86
- Fix CI when running on a macos-arm runner (actions-rs is unmaintained and breaks in that case, so this removes it).