### PR TITLE
RSA PKCS11: fix missing digest info and release 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.1][] (2025-07-04)
+
+- Fix PKCS#1v1.5 RSA signature prefix ([#246][])
+
+[#246]: https://github.com/Nitrokey/nethsm-pkcs11/pull/246
+
+
 ## [1.7.0][] (2025-03-17)
 
 - Support storing the certificates as DER on the Nethsm ([#234][])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +882,7 @@ dependencies = [
  "hex-literal",
  "lazy_static",
  "log",
+ "md-5",
  "nethsm-sdk-rs",
  "once_cell",
  "pem-rfc7468",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,36 +43,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -84,15 +84,15 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -100,7 +100,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -117,15 +117,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -144,24 +144,24 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "config_file"
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -379,12 +379,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -435,20 +435,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -464,9 +464,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "hex"
@@ -510,21 +510,22 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -534,30 +535,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -565,65 +546,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -639,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -649,12 +617,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -671,9 +650,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.6"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
  "log",
@@ -684,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.6"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -701,9 +680,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
@@ -722,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -733,9 +712,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
@@ -776,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "merge"
@@ -819,22 +798,22 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -977,6 +956,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1032,6 +1017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1073,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1091,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1122,7 +1116,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1197,7 +1191,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1205,15 +1199,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -1224,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
@@ -1260,15 +1254,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1371,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1396,16 +1393,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "smallvec"
-version = "1.15.0"
+name = "slab"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1435,9 +1438,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1446,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1470,12 +1473,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1483,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
 dependencies = [
  "env_logger",
  "test-log-macros",
@@ -1494,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1525,12 +1528,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1568,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1578,15 +1580,17 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
  "windows-sys 0.52.0",
 ]
@@ -1603,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1671,9 +1675,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.0.11"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a3e9af6113ecd57b8c63d3cd76a385b2e3881365f1f489e54f49801d0c83ea"
+checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
@@ -1686,14 +1690,14 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf-8",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadf18427d33828c311234884b7ba2afb57143e6e7e69fda7ee883b624661e36"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -1717,12 +1721,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -1750,9 +1748,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1765,9 +1763,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1800,7 +1807,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1809,7 +1816,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1818,14 +1834,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1835,10 +1867,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1847,10 +1891,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1859,10 +1915,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1871,10 +1939,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -1886,16 +1966,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "x509-cert"
@@ -1910,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -1922,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1934,18 +2008,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1980,10 +2054,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1992,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "nethsm_pkcs11"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "arc-swap",
  "base64ct",

--- a/pkcs11/Cargo.toml
+++ b/pkcs11/Cargo.toml
@@ -30,6 +30,8 @@ rayon = "1.8.0"
 syslog = "6.1.1"
 thiserror = "2.0.12"
 arc-swap = "1.7.1"
+hex-literal = "1.0.0"
+md-5 = "0.10.6"
 
 config_file = { path = "config_file" }
 
@@ -39,7 +41,6 @@ rustls-pki-types = "1.11.0"
 socket2 = { version = "0.5.8", features = ["all"] }
 
 [dev-dependencies]
-hex-literal = "1.0.0"
 once_cell = "1.19.0"
 pkcs11 = "0.5.0"
 tempfile = "3.12.0"

--- a/pkcs11/Cargo.toml
+++ b/pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nethsm_pkcs11"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 
 [lib]

--- a/pkcs11/Cargo.toml
+++ b/pkcs11/Cargo.toml
@@ -36,7 +36,7 @@ md-5 = "0.10.6"
 config_file = { path = "config_file" }
 
 # Needed to prevent breaking change with rustls updates
-ureq = { version = "=3.0.11", default-features  = false }
+ureq = { version = "=3.0.12", default-features  = false }
 rustls-pki-types = "1.11.0"
 socket2 = { version = "0.5.8", features = ["all"] }
 

--- a/pkcs11/config_file/src/lib.rs
+++ b/pkcs11/config_file/src/lib.rs
@@ -28,13 +28,13 @@ pub fn config_files() -> Result<Vec<(Vec<u8>, PathBuf)>, ConfigError> {
     ];
 
     if let Ok(home) = std::env::var("HOME") {
-        config_folders.push(format!("{}/.config/nitrokey", home));
+        config_folders.push(format!("{home}/.config/nitrokey"));
     }
 
     let mut res = Vec::new();
     let mut buffer = Vec::new();
     for folder in config_folders {
-        let file_path = format!("{}/{}", folder, CONFIG_FILE_NAME);
+        let file_path = format!("{folder}/{CONFIG_FILE_NAME}");
         if let Ok(mut file) = std::fs::File::open(&file_path) {
             file.read_to_end(&mut buffer).map_err(ConfigError::Io)?;
             res.push((mem::take(&mut buffer), file_path.into()));
@@ -294,9 +294,9 @@ slots:
         let home = "/tmp/home/";
 
         // create a temporary "fake" home folder
-        fs::create_dir_all(format!("{}.config/nitrokey", home)).unwrap();
+        fs::create_dir_all(format!("{home}.config/nitrokey")).unwrap();
         fs::write(
-            format!("{}/.config/nitrokey/{}", home, CONFIG_FILE_NAME),
+            format!("{home}/.config/nitrokey/{CONFIG_FILE_NAME}"),
             config,
         )
         .unwrap();

--- a/pkcs11/src/api/decrypt.rs
+++ b/pkcs11/src/api/decrypt.rs
@@ -24,7 +24,7 @@ pub extern "C" fn C_DecryptInit(
     let mech = match Mechanism::from_ckraw_mech(&raw_mech) {
         Ok(mech) => mech,
         Err(e) => {
-            error!("C_DecryptInit() failed to convert mechanism: {}", e);
+            error!("C_DecryptInit() failed to convert mechanism: {e}");
             return cryptoki_sys::CKR_MECHANISM_INVALID;
         }
     };

--- a/pkcs11/src/api/encrypt.rs
+++ b/pkcs11/src/api/encrypt.rs
@@ -27,7 +27,7 @@ pub extern "C" fn C_EncryptInit(
     let mech = match Mechanism::from_ckraw_mech(&raw_mech) {
         Ok(mech) => mech,
         Err(e) => {
-            error!("C_EncryptInit() failed to convert mechanism: {}", e);
+            error!("C_EncryptInit() failed to convert mechanism: {e}");
             return cryptoki_sys::CKR_MECHANISM_INVALID;
         }
     };
@@ -126,7 +126,7 @@ pub extern "C" fn C_EncryptUpdate(
         return cryptoki_sys::CKR_ARGUMENTS_BAD;
     }
 
-    trace!("C_EncryptUpdate() called with {} bytes", ulPartLen);
+    trace!("C_EncryptUpdate() called with {ulPartLen} bytes");
 
     let data = unsafe { std::slice::from_raw_parts(pPart, ulPartLen as usize) };
 

--- a/pkcs11/src/api/generation.rs
+++ b/pkcs11/src/api/generation.rs
@@ -39,7 +39,7 @@ pub extern "C" fn C_GenerateKey(
     let mech = match Mechanism::from_ckraw_mech(&mech) {
         Ok(mech) => mech,
         Err(e) => {
-            error!("C_GenerateKey() failed to convert mechanism: {}", e);
+            error!("C_GenerateKey() failed to convert mechanism: {e}");
             return cryptoki_sys::CKR_MECHANISM_INVALID;
         }
     };
@@ -56,16 +56,13 @@ pub extern "C" fn C_GenerateKey(
     let key = match session.generate_key(&template, None, &mech) {
         Ok(key) => key,
         Err(e) => {
-            error!("C_GenerateKey() failed to generate key: {:?}", e);
+            error!("C_GenerateKey() failed to generate key: {e:?}");
             return cryptoki_sys::CKR_FUNCTION_FAILED;
         }
     };
 
     if key.is_empty() {
-        error!(
-            "C_GenerateKey() failed to generate key,invalid length: {:?}",
-            key
-        );
+        error!("C_GenerateKey() failed to generate key,invalid length: {key:?}");
         return cryptoki_sys::CKR_FUNCTION_FAILED;
     }
 
@@ -105,13 +102,13 @@ pub extern "C" fn C_GenerateKeyPair(
     trace!("C_GenerateKeyPair() mech: {:?}", mech.type_());
     trace!("C_GenerateKeyPair() mech param len: {:?}", mech.len());
 
-    trace!("Private count: {:?}", ulPrivateKeyAttributeCount);
-    trace!("Public count: {:?}", ulPublicKeyAttributeCount);
+    trace!("Private count: {ulPrivateKeyAttributeCount:?}");
+    trace!("Public count: {ulPublicKeyAttributeCount:?}");
 
     let mech = match Mechanism::from_ckraw_mech(&mech) {
         Ok(mech) => mech,
         Err(e) => {
-            error!("C_GenerateKeyPair() failed to convert mechanism: {}", e);
+            error!("C_GenerateKeyPair() failed to convert mechanism: {e}");
             return cryptoki_sys::CKR_MECHANISM_INVALID;
         }
     };
@@ -138,16 +135,13 @@ pub extern "C" fn C_GenerateKeyPair(
     let keys = match session.generate_key(&private_template, Some(&public_template), &mech) {
         Ok(keys) => keys,
         Err(e) => {
-            error!("C_GenerateKeyPair() failed to generate key: {:?}", e);
+            error!("C_GenerateKeyPair() failed to generate key: {e:?}");
             return cryptoki_sys::CKR_FUNCTION_FAILED;
         }
     };
 
     if keys.len() < 2 {
-        error!(
-            "C_GenerateKeyPair() failed to generate key,invalid length: {:?}",
-            keys
-        );
+        error!("C_GenerateKeyPair() failed to generate key,invalid length: {keys:?}");
         return cryptoki_sys::CKR_FUNCTION_FAILED;
     }
 
@@ -233,8 +227,7 @@ pub extern "C" fn C_GenerateRandom(
 
     if ulRandomLen > 1024 {
         error!(
-            "C_GenerateRandom() called with invalid length {}, NetHSM supports up to 1024 bytes",
-            ulRandomLen
+            "C_GenerateRandom() called with invalid length {ulRandomLen}, NetHSM supports up to 1024 bytes"
         );
 
         return cryptoki_sys::CKR_ARGUMENTS_BAD;
@@ -245,10 +238,7 @@ pub extern "C" fn C_GenerateRandom(
         .login_ctx
         .can_run_mode(crate::backend::login::UserMode::Operator)
     {
-        error!(
-            "C_GenerateRandom() called with session not connected as operator {}.",
-            hSession
-        );
+        error!("C_GenerateRandom() called with session not connected as operator {hSession}.");
         return cryptoki_sys::CKR_USER_NOT_LOGGED_IN;
     }
 
@@ -265,7 +255,7 @@ pub extern "C" fn C_GenerateRandom(
     ) {
         Ok(data) => data,
         Err(e) => {
-            error!("C_GenerateRandom() failed to generate random data: {:?}", e);
+            error!("C_GenerateRandom() failed to generate random data: {e:?}");
             return cryptoki_sys::CKR_FUNCTION_FAILED;
         }
     };
@@ -275,7 +265,7 @@ pub extern "C" fn C_GenerateRandom(
     let raw_data = match Base64::decode_vec(&data.entity.random) {
         Ok(raw_data) => raw_data,
         Err(e) => {
-            error!("C_GenerateRandom() failed to decode random data: {:?}", e);
+            error!("C_GenerateRandom() failed to decode random data: {e:?}");
             return cryptoki_sys::CKR_FUNCTION_FAILED;
         }
     };

--- a/pkcs11/src/api/mod.rs
+++ b/pkcs11/src/api/mod.rs
@@ -44,7 +44,7 @@ pub extern "C" fn C_GetFunctionList(
 
 #[no_mangle]
 pub extern "C" fn C_Initialize(pInitArgs: CK_VOID_PTR) -> CK_RV {
-    trace!("C_Initialize() called with args: {:?}", pInitArgs);
+    trace!("C_Initialize() called with args: {pInitArgs:?}");
 
     let res = crate::config::initialization::initialize();
     let device = match res {
@@ -79,8 +79,8 @@ pub extern "C" fn C_Initialize(pInitArgs: CK_VOID_PTR) -> CK_RV {
         let flags = args.flags;
         let CreateMutex = args.CreateMutex;
 
-        trace!("C_Initialize() called with flags: {:?}", flags);
-        trace!("C_Initialize() called with CreateMutex: {:?}", CreateMutex);
+        trace!("C_Initialize() called with flags: {flags:?}");
+        trace!("C_Initialize() called with CreateMutex: {CreateMutex:?}");
 
         // currently we don't support custom locking
         // if the flag is not set and the mutex functions are not null, the program asks us to use only the mutex functions, we can't do that

--- a/pkcs11/src/api/object.rs
+++ b/pkcs11/src/api/object.rs
@@ -13,7 +13,7 @@ pub extern "C" fn C_FindObjectsInit(
     pTemplate: cryptoki_sys::CK_ATTRIBUTE_PTR,
     ulCount: cryptoki_sys::CK_ULONG,
 ) -> cryptoki_sys::CK_RV {
-    trace!("C_FindObjectsInit() called with session {}", hSession);
+    trace!("C_FindObjectsInit() called with session {hSession}");
 
     if ulCount > 0 && pTemplate.is_null() {
         return cryptoki_sys::CKR_ARGUMENTS_BAD;
@@ -22,7 +22,7 @@ pub extern "C" fn C_FindObjectsInit(
     let template = unsafe { CkRawAttrTemplate::from_raw_ptr(pTemplate, ulCount as usize) };
 
     lock_session!(hSession, session);
-    trace!("C_FindObjectsInit() template: {:?}", template);
+    trace!("C_FindObjectsInit() template: {template:?}");
     match session.enum_init(template) {
         Ok(_) => cryptoki_sys::CKR_OK,
         Err(err) => err.into(),
@@ -44,14 +44,14 @@ pub extern "C" fn C_FindObjects(
 
     lock_session!(hSession, session);
 
-    trace!("C_FindObjects() ulMaxObjectCount: {}", ulMaxObjectCount);
+    trace!("C_FindObjects() ulMaxObjectCount: {ulMaxObjectCount}");
     let objects = match session.enum_next_chunk(ulMaxObjectCount as usize) {
         Ok(objects) => objects,
         Err(err) => {
             return err.into();
         }
     };
-    trace!("C_FindObjects() objects: {:?}", objects);
+    trace!("C_FindObjects() objects: {objects:?}");
 
     let returned_count = objects.len();
 
@@ -81,7 +81,7 @@ pub extern "C" fn C_GetAttributeValue(
     pTemplate: cryptoki_sys::CK_ATTRIBUTE_PTR,
     ulCount: cryptoki_sys::CK_ULONG,
 ) -> cryptoki_sys::CK_RV {
-    trace!("C_GetAttributeValue() called for object {}.", hObject);
+    trace!("C_GetAttributeValue() called for object {hObject}.");
 
     if pTemplate.is_null() {
         return cryptoki_sys::CKR_ARGUMENTS_BAD;
@@ -92,10 +92,7 @@ pub extern "C" fn C_GetAttributeValue(
     let object = match session.get_object(hObject) {
         Some(object) => object,
         None => {
-            error!(
-                "C_GetAttributeValue() called with invalid object handle {}.",
-                hObject
-            );
+            error!("C_GetAttributeValue() called with invalid object handle {hObject}.");
             return cryptoki_sys::CKR_OBJECT_HANDLE_INVALID;
         }
     };
@@ -133,7 +130,7 @@ pub extern "C" fn C_GetObjectSize(
     let object = match session.get_object(hObject) {
         Some(object) => object,
         None => {
-            error!("function called with invalid object handle {}.", hObject);
+            error!("function called with invalid object handle {hObject}.");
             return cryptoki_sys::CKR_OBJECT_HANDLE_INVALID;
         }
     };
@@ -206,7 +203,7 @@ pub extern "C" fn C_DestroyObject(
     hSession: cryptoki_sys::CK_SESSION_HANDLE,
     hObject: cryptoki_sys::CK_OBJECT_HANDLE,
 ) -> cryptoki_sys::CK_RV {
-    trace!("C_DestroyObject() called : {}", hObject);
+    trace!("C_DestroyObject() called : {hObject}");
 
     lock_session!(hSession, session);
 
@@ -250,10 +247,7 @@ pub extern "C" fn C_SetAttributeValue(
         let object = match session.get_object(hObject) {
             Some(object) => object,
             None => {
-                error!(
-                    "C_SetAttributeValue() called with invalid object handle {}.",
-                    hObject
-                );
+                error!("C_SetAttributeValue() called with invalid object handle {hObject}.");
                 return cryptoki_sys::CKR_OBJECT_HANDLE_INVALID;
             }
         };

--- a/pkcs11/src/api/pin.rs
+++ b/pkcs11/src/api/pin.rs
@@ -56,10 +56,7 @@ pub extern "C" fn C_SetPIN(
         .login_ctx
         .can_run_mode(crate::backend::login::UserMode::OperatorOrAdministrator)
     {
-        error!(
-            "C_SetPIN() called with session not connected as operator {}.",
-            hSession
-        );
+        error!("C_SetPIN() called with session not connected as operator {hSession}.");
         return cryptoki_sys::CKR_USER_NOT_LOGGED_IN;
     }
     session.login_ctx.change_pin(new_pin.to_string())

--- a/pkcs11/src/api/session.rs
+++ b/pkcs11/src/api/session.rs
@@ -12,11 +12,7 @@ pub extern "C" fn C_OpenSession(
     _Notify: cryptoki_sys::CK_NOTIFY,
     phSession: cryptoki_sys::CK_SESSION_HANDLE_PTR,
 ) -> cryptoki_sys::CK_RV {
-    trace!(
-        "C_OpenSession() called with slotID {}, flags {}",
-        slotID,
-        flags
-    );
+    trace!("C_OpenSession() called with slotID {slotID}, flags {flags}");
 
     if phSession.is_null() {
         return cryptoki_sys::CKR_ARGUMENTS_BAD;
@@ -29,7 +25,7 @@ pub extern "C" fn C_OpenSession(
     let slot = match get_slot(slotID as usize) {
         Ok(slot) => slot,
         Err(_) => {
-            error!("C_OpenSession() called with invalid slotID {}.", slotID);
+            error!("C_OpenSession() called with invalid slotID {slotID}.");
             return cryptoki_sys::CKR_SLOT_ID_INVALID;
         }
     };
@@ -38,7 +34,7 @@ pub extern "C" fn C_OpenSession(
     let mut manager = SESSION_MANAGER.lock().unwrap();
     let session = manager.create_session(slotID, slot, flags);
 
-    trace!("C_OpenSession() created session: {:?}", session);
+    trace!("C_OpenSession() created session: {session:?}");
 
     unsafe {
         std::ptr::write(phSession, session);
@@ -49,16 +45,13 @@ pub extern "C" fn C_OpenSession(
 
 #[no_mangle]
 pub extern "C" fn C_CloseSession(hSession: cryptoki_sys::CK_SESSION_HANDLE) -> cryptoki_sys::CK_RV {
-    trace!("C_CloseSession() called with session handle {}.", hSession);
+    trace!("C_CloseSession() called with session handle {hSession}.");
 
     let mut manager = SESSION_MANAGER.lock().unwrap();
     let result = manager.delete_session(hSession);
 
     if result.is_none() {
-        error!(
-            "C_CloseSession() called with invalid session handle {}.",
-            hSession
-        );
+        error!("C_CloseSession() called with invalid session handle {hSession}.");
         return cryptoki_sys::CKR_SESSION_HANDLE_INVALID;
     }
 
@@ -70,10 +63,7 @@ pub extern "C" fn C_CloseAllSessions(slotID: cryptoki_sys::CK_SLOT_ID) -> crypto
     trace!("C_CloseAllSessions() called");
 
     if get_slot(slotID as usize).is_err() {
-        error!(
-            "C_CloseAllSessions() called with invalid slotID {}.",
-            slotID
-        );
+        error!("C_CloseAllSessions() called with invalid slotID {slotID}.");
         return cryptoki_sys::CKR_SLOT_ID_INVALID;
     }
 
@@ -89,10 +79,7 @@ pub extern "C" fn C_GetSessionInfo(
     hSession: cryptoki_sys::CK_SESSION_HANDLE,
     pInfo: cryptoki_sys::CK_SESSION_INFO_PTR,
 ) -> cryptoki_sys::CK_RV {
-    trace!(
-        "C_GetSessionInfo() called with session handle {}.",
-        hSession
-    );
+    trace!("C_GetSessionInfo() called with session handle {hSession}.");
 
     if pInfo.is_null() {
         return cryptoki_sys::CKR_ARGUMENTS_BAD;

--- a/pkcs11/src/api/sign.rs
+++ b/pkcs11/src/api/sign.rs
@@ -12,11 +12,7 @@ pub extern "C" fn C_SignInit(
     pMechanism: *mut cryptoki_sys::CK_MECHANISM,
     hKey: cryptoki_sys::CK_OBJECT_HANDLE,
 ) -> cryptoki_sys::CK_RV {
-    trace!(
-        "C_SignInit() called with hKey {} and session {}",
-        hKey,
-        hSession
-    );
+    trace!("C_SignInit() called with hKey {hKey} and session {hSession}");
 
     let raw_mech = match unsafe { CkRawMechanism::from_raw_ptr(pMechanism) } {
         Some(mech) => mech,
@@ -28,7 +24,7 @@ pub extern "C" fn C_SignInit(
     let mech = match Mechanism::from_ckraw_mech(&raw_mech) {
         Ok(mech) => mech,
         Err(e) => {
-            error!("C_SignInit() failed to convert mechanism: {}", e);
+            error!("C_SignInit() failed to convert mechanism: {e}");
             return cryptoki_sys::CKR_MECHANISM_INVALID;
         }
     };

--- a/pkcs11/src/api/token.rs
+++ b/pkcs11/src/api/token.rs
@@ -77,7 +77,7 @@ pub extern "C" fn C_GetSlotInfo(
     slotID: cryptoki_sys::CK_SLOT_ID,
     pInfo: cryptoki_sys::CK_SLOT_INFO_PTR,
 ) -> cryptoki_sys::CK_RV {
-    trace!("C_GetSlotInfo() called with slotID: {}", slotID);
+    trace!("C_GetSlotInfo() called with slotID: {slotID}");
 
     if pInfo.is_null() {
         return cryptoki_sys::CKR_ARGUMENTS_BAD;
@@ -106,7 +106,7 @@ pub extern "C" fn C_GetSlotInfo(
     let info = match result {
         Ok(info) => info.entity,
         Err(e) => {
-            trace!("Error getting info: {:?}", e);
+            trace!("Error getting info: {e:?}");
             InfoData {
                 product: "unknown".to_string(),
                 vendor: "unknown".to_string(),
@@ -124,7 +124,7 @@ pub extern "C" fn C_GetSlotInfo(
     let system_state = match result {
         Ok(info) => info.entity,
         Err(e) => {
-            trace!("Error getting system state: {:?}", e);
+            trace!("Error getting system state: {e:?}");
             HealthStateData {
                 state: SystemState::Unprovisioned,
             }
@@ -155,7 +155,7 @@ pub extern "C" fn C_GetTokenInfo(
     slotID: cryptoki_sys::CK_SLOT_ID,
     pInfo: cryptoki_sys::CK_TOKEN_INFO_PTR,
 ) -> cryptoki_sys::CK_RV {
-    trace!("C_GetTokenInfo() called with slotID: {}", slotID);
+    trace!("C_GetTokenInfo() called with slotID: {slotID}");
 
     // get the slot
     let slot = match get_slot(slotID as usize) {
@@ -181,7 +181,7 @@ pub extern "C" fn C_GetTokenInfo(
     let info = match result {
         Ok(info) => info,
         Err(e) => {
-            error!("Error getting info: {:?}", e);
+            error!("Error getting info: {e:?}");
             return cryptoki_sys::CKR_FUNCTION_FAILED;
         }
     };
@@ -195,7 +195,7 @@ pub extern "C" fn C_GetTokenInfo(
     if login_ctx.can_run_mode(crate::backend::login::UserMode::Administrator) {
         match login_ctx.try_(default_api::system_info_get, UserMode::Administrator) {
             Err(e) => {
-                warn!("Error getting system info: {:?}", e);
+                warn!("Error getting system info: {e:?}");
             }
             Ok(system_info) => {
                 serial_number = system_info.entity.device_id;
@@ -510,7 +510,7 @@ mod tests {
         let mut slot = 15;
         let result = C_WaitForSlotEvent(0, &mut slot, std::ptr::null_mut());
         handle.join().unwrap();
-        println!("slot: {}", slot);
+        println!("slot: {slot}");
         assert_eq!(result, cryptoki_sys::CKR_CRYPTOKI_NOT_INITIALIZED);
     }
 

--- a/pkcs11/src/backend/db/object.rs
+++ b/pkcs11/src/backend/db/object.rs
@@ -215,7 +215,7 @@ fn configure_ec(key_data: &PublicKey) -> Result<KeyData, Error> {
 
     let size = key_size(&key_data.r#type).ok_or(Error::KeyField("type".to_string()))?;
 
-    trace!("EC key data: {:?}", ec_points);
+    trace!("EC key data: {ec_points:?}");
 
     let mut ec_point_bytes = Base64::decode_vec(ec_points)?;
 
@@ -226,7 +226,7 @@ fn configure_ec(key_data: &PublicKey) -> Result<KeyData, Error> {
         ec_point_bytes.insert(0, 0);
     }
 
-    trace!("EC key data bytes: {:?}", ec_point_bytes);
+    trace!("EC key data bytes: {ec_point_bytes:?}");
 
     let encoded_points = OctetString::new(ec_point_bytes).unwrap().to_der().unwrap();
 

--- a/pkcs11/src/backend/decrypt.rs
+++ b/pkcs11/src/backend/decrypt.rs
@@ -61,7 +61,7 @@ impl DecryptCtx {
                 MechMode::Decrypt,
                 self.mechanism.clone(),
             ))?;
-        trace!("Decrypt with mode: {:?}", mode);
+        trace!("Decrypt with mode: {mode:?}");
 
         let iv = self
             .mechanism

--- a/pkcs11/src/backend/encrypt.rs
+++ b/pkcs11/src/backend/encrypt.rs
@@ -32,19 +32,13 @@ impl EncryptCtx {
         let api_mech = match mechanism.to_api_mech(MechMode::Encrypt) {
             Some(mech) => mech,
             None => {
-                debug!(
-                    "Tried to encrypt with an invalid mechanism: {:?}",
-                    mechanism
-                );
+                debug!("Tried to encrypt with an invalid mechanism: {mechanism:?}");
                 return Err(Error::InvalidMechanismMode(MechMode::Encrypt, mechanism));
             }
         };
 
         if !key.mechanisms.contains(&api_mech) {
-            debug!(
-                "Tried to encrypt with an invalid mechanism: {:?}",
-                mechanism
-            );
+            debug!("Tried to encrypt with an invalid mechanism: {mechanism:?}");
             return Err(Error::InvalidMechanism(
                 (key.id.clone(), key.kind),
                 mechanism,
@@ -104,12 +98,12 @@ fn encrypt_data(
         MechMode::Encrypt,
         mechanism.clone(),
     ))?;
-    trace!("Signing with mode: {:?}", mode);
+    trace!("Signing with mode: {mode:?}");
 
     let iv = mechanism
         .iv()
         .map(|iv| Base64::encode_string(iv.as_slice()));
-    trace!("iv: {:?}", iv);
+    trace!("iv: {iv:?}");
 
     let output = login_ctx
         .try_(

--- a/pkcs11/src/backend/key.rs
+++ b/pkcs11/src/backend/key.rs
@@ -53,7 +53,7 @@ pub fn parse_attributes(template: &CkRawAttrTemplate) -> Result<ParsedAttributes
                 Some(val) => {
                     parsed.key_class = match ObjectKind::from(val) {
                         ObjectKind::Other => {
-                            debug!("Class not supported: {:?}", val);
+                            debug!("Class not supported: {val:?}");
                             None
                         }
 
@@ -87,7 +87,7 @@ pub fn parse_attributes(template: &CkRawAttrTemplate) -> Result<ParsedAttributes
                     .map(|val| String::from_utf8(val.to_vec()))
                     .transpose()
                     .map_err(Error::StringParse)?;
-                trace!("label: {:?}", label);
+                trace!("label: {label:?}");
                 if parsed.id.is_none() {
                     parsed.id = label;
                 }
@@ -438,7 +438,7 @@ pub fn generate_key_from_template(
         .as_ref()
         .and_then(|p| p.value_len.or(p.modulus_bits)));
 
-    trace!("length: {:?}", length);
+    trace!("length: {length:?}");
 
     let mut key_type = mechanism.to_key_type();
 
@@ -487,7 +487,7 @@ fn fetch_one_key(
     ) {
         Ok(key_data) => key_data.entity,
         Err(err) => {
-            debug!("Failed to fetch key {}: {:?}", key_id, err);
+            debug!("Failed to fetch key {key_id}: {err:?}");
             if matches!(
                 err,
                 Error::Api(ApiError::ResponseError(backend::ResponseContent {
@@ -594,7 +594,7 @@ pub fn fetch_one(
         match fetch_one_certificate(&key.id, None, login_ctx) {
             Ok(cert) => acc.push(cert),
             Err(err) => {
-                debug!("Failed to fetch certificate: {:?}", err);
+                debug!("Failed to fetch certificate: {err:?}");
             }
         }
     }

--- a/pkcs11/src/backend/login.rs
+++ b/pkcs11/src/backend/login.rs
@@ -172,7 +172,7 @@ impl LoginCtx {
     }
 
     pub fn login(&mut self, user_type: CK_USER_TYPE, pin: String) -> Result<(), LoginError> {
-        trace!("Login as {:?} with pin", user_type);
+        trace!("Login as {user_type:?} with pin");
 
         let (user_status, user_mode) = match user_type {
             CKU_CONTEXT_SPECIFIC => return Err(LoginError::InvalidUser),
@@ -478,7 +478,7 @@ impl LoginCtx {
         ) {
             Ok(_) => CKR_OK,
             Err(err) => {
-                error!("Failed to change pin: {:?}", err);
+                error!("Failed to change pin: {err:?}");
                 CKR_DEVICE_ERROR
             }
         }

--- a/pkcs11/src/backend/mechanism.rs
+++ b/pkcs11/src/backend/mechanism.rs
@@ -65,9 +65,9 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match &self {
-            Error::CkRaw(e) => write!(f, "CkRaw error: {:?}", e),
-            Error::UnknownMech(t) => write!(f, "Unknown mechanism {}", t),
-            Error::UnknownDigest(t) => write!(f, "Unknown digest {}", t),
+            Error::CkRaw(e) => write!(f, "CkRaw error: {e:?}"),
+            Error::UnknownMech(t) => write!(f, "Unknown mechanism {t}"),
+            Error::UnknownDigest(t) => write!(f, "Unknown digest {t}"),
         }
     }
 }
@@ -304,7 +304,7 @@ impl Mechanism {
 
                 let hash_alg = params.hashAlg;
 
-                trace!("params.hashAlg: {:?}", hash_alg);
+                trace!("params.hashAlg: {hash_alg:?}");
                 Self::RsaPkcsPss(
                     MechDigest::from_ck_mech(params.hashAlg)
                         .ok_or(Error::UnknownDigest(hash_alg))?,

--- a/pkcs11/src/backend/mod.rs
+++ b/pkcs11/src/backend/mod.rs
@@ -125,7 +125,7 @@ impl From<std::string::FromUtf8Error> for Error {
 impl From<Error> for CK_RV {
     fn from(err: Error) -> Self {
         // diplay the error when converting to CK_RV
-        error!("{}", err);
+        error!("{err}");
         match err {
             Error::Der(_) => CKR_DEVICE_ERROR,
             Error::Pem(_) => CKR_DEVICE_ERROR,
@@ -168,55 +168,54 @@ impl From<Error> for CK_RV {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let msg = match self {
-            Error::Der(err) => format!("DER error: {:?}", err),
-            Error::Pem(err) => format!("PEM error: {:?}", err),
+            Error::Der(err) => format!("DER error: {err:?}"),
+            Error::Pem(err) => format!("PEM error: {err:?}"),
             Error::InvalidEncryptedDataLength => "Invalid encrypted data length".to_string(),
             Error::InvalidData => "Invalid input data".to_string(),
             Error::InvalidDataLength => "Invalid input data length".to_string(),
             Error::InvalidObjectHandle(handle) => {
-                format!("Object handle does not exist: {}", handle)
+                format!("Object handle does not exist: {handle}")
             }
             Error::OperationNotInitialized => "Operation not initialized".to_string(),
             Error::LibraryNotInitialized => "Library not initialized".to_string(),
             Error::DbLock => "Internal mutex lock error".to_string(),
             Error::KeyField(field) => {
-                format!("Key field {} received from the NetHSM is not valid", field)
+                format!("Key field {field} received from the NetHSM is not valid")
             }
             Error::OperationActive => "An operation is already active for this session".to_string(),
             Error::Login(err) => err.to_string(),
-            Error::NotLoggedIn(mode) => format!(
-                "The module needs to be logged in as {:?}, check the configuration",
-                mode
-            ),
+            Error::NotLoggedIn(mode) => {
+                format!("The module needs to be logged in as {mode:?}, check the configuration")
+            }
             Error::InvalidMechanism(obj, mech) => {
                 format!(
                     "The mechanism {:?} not supported for {:?} {}",
                     mech, obj.1, obj.0
                 )
             }
-            Error::InvalidAttribute(attr) => format!("Invalid attribute: {:?}", attr),
-            Error::MissingAttribute(attr) => format!("Missing attribute: {:?}", attr),
+            Error::InvalidAttribute(attr) => format!("Invalid attribute: {attr:?}"),
+            Error::MissingAttribute(attr) => format!("Missing attribute: {attr:?}"),
             Error::ObjectClassNotSupported => "Object class not supported".to_string(),
             Error::InvalidMechanismMode(mode, mechanism) => {
-                format!("Unable to use mechanim {:?} for {:?}", mechanism, mode)
+                format!("Unable to use mechanim {mechanism:?} for {mode:?}")
             }
             Error::Api(err) => match err {
                 ApiError::NoInstance => "No valid instance in the slot".to_string(),
-                ApiError::Ureq(err) => format!("Request error : {}", err),
-                ApiError::Serde(err) => format!("Serde error: {:?}", err),
-                ApiError::Io(err) => format!("IO error: {:?}", err),
+                ApiError::Ureq(err) => format!("Request error : {err}"),
+                ApiError::Serde(err) => format!("Serde error: {err:?}"),
+                ApiError::Io(err) => format!("IO error: {err:?}"),
                 ApiError::ResponseError(resp) => match resp.status {
                     404 => "Key not found".to_string(),
                     401 | 403 => "Invalid credentials".to_string(),
                     412 => "The NetHSM is not set up properly".to_string(),
-                    _ => format!("Api error: {:?}", resp),
+                    _ => format!("Api error: {resp:?}"),
                 },
-                ApiError::StringParse(err) => format!("String parse error: {:?}", err),
+                ApiError::StringParse(err) => format!("String parse error: {err:?}"),
                 ApiError::InstanceRemoved => "Failed to connect to instance".to_string(),
             },
-            Error::Base64(err) => format!("Base64 Decode error: {:?}", err),
-            Error::StringParse(err) => format!("String parse error: {:?}", err),
+            Error::Base64(err) => format!("Base64 Decode error: {err:?}"),
+            Error::StringParse(err) => format!("String parse error: {err:?}"),
         };
-        write!(f, "{}", msg)
+        write!(f, "{msg}")
     }
 }

--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -186,8 +186,8 @@ impl Session {
             return Err(Error::OperationActive);
         }
 
-        trace!("sign_init() called with key handle {}", key_handle);
-        trace!("sign_init() called with mechanism {:?}", mechanism);
+        trace!("sign_init() called with key handle {key_handle}");
+        trace!("sign_init() called with mechanism {mechanism:?}");
 
         // get key id from the handle
 
@@ -446,11 +446,11 @@ impl Session {
                             &self.db.0,
                         ) {
                             Ok(cert) => {
-                                trace!("Fetched certificate: {:?}", cert);
+                                trace!("Fetched certificate: {cert:?}");
                                 results.push(cert);
                             }
                             Err(err) => {
-                                debug!("Failed to fetch certificate: {:?}", err);
+                                debug!("Failed to fetch certificate: {err:?}");
                             }
                         }
                     }
@@ -758,8 +758,7 @@ mod test {
                         Err(Error::Api(ApiError::Ureq(r))) => {
                             assert!(
                                 r.ends_with(": status code 404"),
-                                "expected 404 error, got {}",
-                                r
+                                "expected 404 error, got {r}"
                             );
                         }
                         // FIXME: check for error 404 here

--- a/pkcs11/src/backend/sign.rs
+++ b/pkcs11/src/backend/sign.rs
@@ -29,26 +29,23 @@ impl SignCtx {
         }
 
         let sign_name = mechanism.sign_name().ok_or_else(|| {
-            debug!("Tried to sign with an invalid mechanism: {:?}", mechanism);
+            debug!("Tried to sign with an invalid mechanism: {mechanism:?}");
             Error::InvalidMechanismMode(MechMode::Sign, mechanism.clone())
         })?;
 
         let api_mech = match mechanism.to_api_mech(MechMode::Sign) {
             Some(mech) => mech,
             None => {
-                debug!("Tried to sign with an invalid mechanism: {:?}", mechanism);
+                debug!("Tried to sign with an invalid mechanism: {mechanism:?}");
                 return Err(Error::InvalidMechanismMode(MechMode::Sign, mechanism));
             }
         };
 
-        trace!("Signing with mechanism: {:?}", mechanism);
+        trace!("Signing with mechanism: {mechanism:?}");
         trace!("key mechanisms: {:?}", key.mechanisms);
 
         if !key.mechanisms.contains(&api_mech) {
-            debug!(
-                "Tried to sign with an invalid mechanism for this key: {:?}",
-                mechanism
-            );
+            debug!("Tried to sign with an invalid mechanism for this key: {mechanism:?}");
             return Err(Error::InvalidMechanism((key.id, key.kind), mechanism));
         }
 
@@ -98,7 +95,7 @@ impl SignCtx {
         let b64_message = Base64::encode_string(data.as_slice());
 
         let mode = self.sign_name;
-        trace!("Signing with mode: {:?}", mode);
+        trace!("Signing with mode: {mode:?}");
 
         let signature = login_ctx.try_(
             |conf| {

--- a/pkcs11/src/backend/sign.rs
+++ b/pkcs11/src/backend/sign.rs
@@ -65,23 +65,23 @@ impl SignCtx {
 
     pub fn sign_final(&self, login_ctx: &LoginCtx) -> Result<Vec<u8>, Error> {
         // helper function to hash the data with the correct algorithm
-        fn hasher<D: Digest>(data: &[u8]) -> Vec<u8> {
+        fn hasher<D: Digest>(data: &[u8], prefix: &'static [u8]) -> Vec<u8> {
             let mut hasher = D::new();
             hasher.update(data);
-            hasher.finalize().to_vec()
+            let mut res = Vec::from(prefix);
+            res.extend_from_slice(&hasher.finalize());
+            res
         }
 
-        let mut data = if let Some(digest) = self.mechanism.internal_digest() {
-            let hasher_fn = match digest {
-                MechDigest::Sha1 => hasher::<sha1::Sha1>,
-                MechDigest::Sha224 => hasher::<sha2::Sha224>,
-                MechDigest::Sha256 => hasher::<sha2::Sha256>,
-                MechDigest::Sha384 => hasher::<sha2::Sha384>,
-                MechDigest::Sha512 => hasher::<sha2::Sha512>,
-                // should never happen
-                _ => hasher::<sha1::Sha1>,
-            };
-            hasher_fn(&self.data)
+        let mut data = if let Some((digest, prefix)) = self.mechanism.internal_digest_and_prefix() {
+            match digest {
+                MechDigest::Md5 => hasher::<md5::Md5>(&self.data, prefix),
+                MechDigest::Sha1 => hasher::<sha1::Sha1>(&self.data, prefix),
+                MechDigest::Sha224 => hasher::<sha2::Sha224>(&self.data, prefix),
+                MechDigest::Sha256 => hasher::<sha2::Sha256>(&self.data, prefix),
+                MechDigest::Sha384 => hasher::<sha2::Sha384>(&self.data, prefix),
+                MechDigest::Sha512 => hasher::<sha2::Sha512>(&self.data, prefix),
+            }
         } else {
             self.data.clone()
         };

--- a/pkcs11/src/ureq/rustls_connector.rs
+++ b/pkcs11/src/ureq/rustls_connector.rs
@@ -56,7 +56,7 @@ impl<In: Transport> Connector<In> for RustlsConnector {
             .host()
             .try_into()
             .map_err(|e| {
-                debug!("rustls invalid dns name: {}", e);
+                debug!("rustls invalid dns name: {e}");
                 Error::Tls("Rustls invalid dns name error")
             })?;
 

--- a/pkcs11/src/ureq/tcp_connector.rs
+++ b/pkcs11/src/ureq/tcp_connector.rs
@@ -88,7 +88,7 @@ fn try_connect(
             Ok(v) => return Ok(v),
             // Intercept ConnectionRefused to try next addrs
             Err(Error::Io(e)) if e.kind() == io::ErrorKind::ConnectionRefused => {
-                trace!("{} connection refused", addr);
+                trace!("{addr} connection refused");
                 continue;
             }
             // Other errors bail
@@ -108,7 +108,7 @@ fn try_connect_single(
     timeout: NextTimeout,
     config: &Config,
 ) -> Result<TcpStream, Error> {
-    trace!("Try connect TcpStream to {}", addr);
+    trace!("Try connect TcpStream to {addr}");
 
     let maybe_stream = if let Some(when) = timeout_not_zero(&timeout) {
         TcpStream::connect_timeout(&addr, *when)
@@ -129,7 +129,7 @@ fn try_connect_single(
         stream.set_nodelay(true)?;
     }
 
-    debug!("Connected TcpStream to {}", addr);
+    debug!("Connected TcpStream to {addr}");
 
     Ok(stream)
 }

--- a/tools/tests/sign_rsa_pkcs_sha1.sh
+++ b/tools/tests/sign_rsa_pkcs_sha1.sh
@@ -13,4 +13,4 @@ curl -s --fail-with-body -k -u operator:opPassphrase -v -X GET \
 echo 'NetHSM rulez!' | pkcs11-tool --module ./target/debug/libnethsm_pkcs11.so  -v \
   --sign --mechanism SHA1-RSA-PKCS --output-file _data.sig --id $HEXID --signature-format openssl
 
-echo 'NetHSM rulez!' | openssl dgst -sha1 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin
+echo 'NetHSM rulez!' | openssl dgst -sha1 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin -pkeyopt digest:sha1

--- a/tools/tests/sign_rsa_pkcs_sha224.sh
+++ b/tools/tests/sign_rsa_pkcs_sha224.sh
@@ -13,4 +13,4 @@ curl -s --fail-with-body -k -u operator:opPassphrase -v -X GET \
 echo 'NetHSM rulez!' | pkcs11-tool --module ./target/debug/libnethsm_pkcs11.so  -v \
   --sign --mechanism SHA224-RSA-PKCS --output-file _data.sig --id $HEXID --signature-format openssl
 
-echo 'NetHSM rulez!' | openssl dgst -sha224 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin
+echo 'NetHSM rulez!' | openssl dgst -sha224 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin -pkeyopt digest:sha224

--- a/tools/tests/sign_rsa_pkcs_sha256.sh
+++ b/tools/tests/sign_rsa_pkcs_sha256.sh
@@ -13,4 +13,4 @@ curl -s --fail-with-body -k -u operator:opPassphrase -v -X GET \
 echo 'NetHSM rulez!' | pkcs11-tool --module ./target/debug/libnethsm_pkcs11.so  -v \
   --sign --mechanism SHA256-RSA-PKCS --output-file _data.sig --id $HEXID --signature-format openssl
 
-echo 'NetHSM rulez!' | openssl dgst -sha256 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin
+echo 'NetHSM rulez!' | openssl dgst -sha256 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin -pkeyopt digest:sha256

--- a/tools/tests/sign_rsa_pkcs_sha384.sh
+++ b/tools/tests/sign_rsa_pkcs_sha384.sh
@@ -13,4 +13,4 @@ curl -s --fail-with-body -k -u operator:opPassphrase -v -X GET \
 echo 'NetHSM rulez!' | pkcs11-tool --module ./target/debug/libnethsm_pkcs11.so  -v \
   --sign --mechanism SHA384-RSA-PKCS --output-file _data.sig --id $HEXID --signature-format openssl
 
-echo 'NetHSM rulez!' | openssl dgst -sha384 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin
+echo 'NetHSM rulez!' | openssl dgst -sha384 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin -pkeyopt digest:sha384

--- a/tools/tests/sign_rsa_pkcs_sha512.sh
+++ b/tools/tests/sign_rsa_pkcs_sha512.sh
@@ -13,4 +13,4 @@ curl -s --fail-with-body -k -u operator:opPassphrase -v -X GET \
 echo 'NetHSM rulez!' | pkcs11-tool --module ./target/debug/libnethsm_pkcs11.so  -v \
   --sign --mechanism SHA512-RSA-PKCS --output-file _data.sig --id $HEXID --signature-format openssl
 
-echo 'NetHSM rulez!' | openssl dgst -sha512 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin
+echo 'NetHSM rulez!' | openssl dgst -sha512 -binary | openssl pkeyutl -verify -inkey _public.pem -sigfile _data.sig -pubin -pkeyopt digest:sha512


### PR DESCRIPTION
- Fix the missing digestinfo in pkcs#1v1.5 signatures
- Adjust tests for this
- Update dependencies
- Prepare release 1.7.1