### PR TITLE
Refactor release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo build --release
 
       - name: rename file
-        run: mv target/release/nethsm_pkcs11.dll ${{ env.FILE_NAME }}
+        run: mv -Verbose target/release/nethsm_pkcs11.dll ${{ env.FILE_NAME }}
 
       - name: Upload artifacts
         if: ${{ github.event_name != 'release' }}
@@ -66,9 +66,9 @@ jobs:
         run: cargo build --release --target x86_64-apple-darwin
 
       - name: rename file
-        run: mv target/x86_64-apple-darwin/release/libnethsm_pkcs11.dylib ${{ env.FILE_NAME }}
+        run: mv -v target/x86_64-apple-darwin/release/libnethsm_pkcs11.dylib ${{ env.FILE_NAME }}
       - name: rename file arm
-        run: mv target/aarch64-apple-darwin/release/libnethsm_pkcs11.dylib ${{ env.FILE_NAME_ARM }}
+        run: mv -v target/aarch64-apple-darwin/release/libnethsm_pkcs11.dylib ${{ env.FILE_NAME_ARM }}
 
       - name: Upload artifacts
         if: ${{ github.event_name != 'release' }}
@@ -132,7 +132,7 @@ jobs:
         run: cargo build --release
 
       - name: rename file
-        run: mv target/release/libnethsm_pkcs11.so ${{ env.FILE_NAME }}
+        run: mv --verbose target/release/libnethsm_pkcs11.so ${{ env.FILE_NAME }}
 
       - name: Upload artifacts
         if: ${{ github.event_name != 'release' }}
@@ -202,7 +202,7 @@ jobs:
           run: |
             . $HOME/.cargo/env
             cargo build --release --target ${{ matrix.target }}
-            mv target/${{ matrix.target }}/release/libnethsm_pkcs11.so /artifacts/${{env.FILE_NAME}}
+            mv --verbose target/${{ matrix.target }}/release/libnethsm_pkcs11.so /artifacts/${{env.FILE_NAME}}
       - name: Upload artifacts
         if: ${{ github.event_name != 'release' }}
         uses: actions/upload-artifact@v4
@@ -233,7 +233,7 @@ jobs:
         run: ./tools/collect_licenses.sh
 
       - name: rename file
-        run: mv _LICENSE LICENSE
+        run: mv --verbose _LICENSE LICENSE
 
       - name: Upload artifacts
         if: ${{ github.event_name != 'release' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,15 @@ name: Build Rust project on multiple platforms when a new release is created
 on:
   release:
     types: [created]
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-windows:
     runs-on: windows-latest
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-x86_64-windows.dll
+      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-x86_64-windows.dll
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -29,7 +32,15 @@ jobs:
       - name: rename file
         run: mv target/release/nethsm_pkcs11.dll ${{ env.FILE_NAME }}
 
+      - name: Upload artifacts
+        if: ${{ github.event_name != 'release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows
+          path: ${{ env.FILE_NAME }}
+
       - name: Upload to the release
+        if: ${{ github.event_name == 'release' }}
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.FILE_NAME }}
@@ -37,8 +48,8 @@ jobs:
   build-macos:
     runs-on: macos-latest
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-x86_64-macos.dylib
-      FILE_NAME_ARM: nethsm-pkcs11-${{ github.event.release.tag_name }}-aarch64-macos.dylib
+      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-x86_64-macos.dylib
+      FILE_NAME_ARM: nethsm-pkcs11-${{ github.ref_name }}-aarch64-macos.dylib
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -59,7 +70,17 @@ jobs:
       - name: rename file arm
         run: mv target/aarch64-apple-darwin/release/libnethsm_pkcs11.dylib ${{ env.FILE_NAME_ARM }}
 
+      - name: Upload artifacts
+        if: ${{ github.event_name != 'release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos
+          path: |
+            ${{ env.FILE_NAME }}
+            ${{ env.FILE_NAME_ARM }}
+
       - name: Upload to the release
+        if: ${{ github.event_name == 'release' }}
         uses: softprops/action-gh-release@v1
         with:
           files: |
@@ -80,7 +101,7 @@ jobs:
             name: glibc
 
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-x86_64-${{ matrix.name }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-x86_64-${{ matrix.name }}.so
       HOME: /root
     steps:
       - name: Checkout code
@@ -113,7 +134,15 @@ jobs:
       - name: rename file
         run: mv target/release/libnethsm_pkcs11.so ${{ env.FILE_NAME }}
 
+      - name: Upload artifacts
+        if: ${{ github.event_name != 'release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-x86_64-${{ matrix.name }}
+          path: ${{ env.FILE_NAME }}
+
       - name: Upload to the release
+        if: ${{ github.event_name == 'release' }}
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.FILE_NAME }}
@@ -137,7 +166,7 @@ jobs:
           #   distro: ubuntu22.04
           #   target: riscv64gc-unknown-linux-gnu
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-${{ matrix.arch }}-${{ matrix.name }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-${{ matrix.arch }}-${{ matrix.name }}.so
 
     steps:
       - uses: actions/checkout@v3
@@ -174,7 +203,14 @@ jobs:
             . $HOME/.cargo/env
             cargo build --release --target ${{ matrix.target }}
             mv target/${{ matrix.target }}/release/libnethsm_pkcs11.so /artifacts/${{env.FILE_NAME}}
+      - name: Upload artifacts
+        if: ${{ github.event_name != 'release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.arch }}-${{ matrix.name }}
+          path: artifacts/${{ env.FILE_NAME }}
       - uses: softprops/action-gh-release@v1
+        if: ${{ github.event_name == 'release' }}
         with:
           files: artifacts/${{ env.FILE_NAME }}
 
@@ -199,7 +235,15 @@ jobs:
       - name: rename file
         run: mv _LICENSE LICENSE
 
+      - name: Upload artifacts
+        if: ${{ github.event_name != 'release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: licenses
+          path: LICENSE
+
       - name: Upload to the release
+        if: ${{ github.event_name == 'release' }}
         uses: softprops/action-gh-release@v1
         with:
           files: LICENSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   build-windows:
     runs-on: windows-latest
     env:
-      FILE_NAME: nethsm-pkcs11-v${{ github.event.release.tag_name }}-x86_64-windows.dll
+      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-x86_64-windows.dll
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -37,8 +37,8 @@ jobs:
   build-macos:
     runs-on: macos-latest
     env:
-      FILE_NAME: nethsm-pkcs11-v${{ github.event.release.tag_name }}-x86_64-macos.dylib
-      FILE_NAME_ARM: nethsm-pkcs11-v${{ github.event.release.tag_name }}-aarch64-macos.dylib
+      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-x86_64-macos.dylib
+      FILE_NAME_ARM: nethsm-pkcs11-${{ github.event.release.tag_name }}-aarch64-macos.dylib
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -77,7 +77,7 @@ jobs:
         rust-version: [stable]
 
     env:
-      FILE_NAME: nethsm-pkcs11-v${{ github.event.release.tag_name }}-x86_64-${{ matrix.os }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-x86_64-${{ matrix.os }}.so
       HOME: /root
     steps:
       - name: Checkout code
@@ -138,7 +138,7 @@ jobs:
           #   distro: ubuntu22.04
           #   target: riscv64gc-unknown-linux-gnu
     env:
-      FILE_NAME: nethsm-pkcs11-v${{ github.event.release.tag_name }}-${{ matrix.arch }}-${{ matrix.distro }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-${{ matrix.arch }}-${{ matrix.distro }}.so
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,14 @@ jobs:
 
     strategy:
       matrix:
-        os: ["alpine:3.18", "debian:12", "fedora:39", "fedora:40", "ubuntu:22.04", "ubuntu:24.04"]
-        rust-version: [stable]
+        include:
+          - os: "alpine:3.18"
+            name: musl
+          - os: "ubuntu:22.04"
+            name: glibc
 
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-x86_64-${{ matrix.os }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-x86_64-${{ matrix.name }}.so
       HOME: /root
     steps:
       - name: Checkout code
@@ -86,7 +89,7 @@ jobs:
       - name: install dependencies
         run: |
           case ${{matrix.os}} in 
-            ubuntu* | debian* )
+            ubuntu*)
               apt-get update
               apt-get install -y curl gcc
               ;;
@@ -94,16 +97,13 @@ jobs:
               apk add curl musl-dev gcc 
               echo RUSTFLAGS="-C target-feature=-crt-static" >> $GITHUB_ENV
               ;;
-            fedora*)
-              dnf install -y curl gcc
-              ;;
           esac
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust-version }}
+          toolchain: stable
 
       - uses: Swatinem/rust-cache@v2
 
@@ -125,20 +125,19 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-            distro: bullseye
-            target: aarch64-unknown-linux-gnu
-          - arch: aarch64
             distro: ubuntu22.04
             target: aarch64-unknown-linux-gnu
+            name: glibc
           - arch: aarch64
             distro: alpine_latest
             target: aarch64-unknown-linux-musl
+            name: musl
           # Not supported by ring
           # - arch: riscv64
           #   distro: ubuntu22.04
           #   target: riscv64gc-unknown-linux-gnu
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-${{ matrix.arch }}-${{ matrix.distro }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.event.release.tag_name }}-${{ matrix.arch }}-${{ matrix.name }}.so
 
     steps:
       - uses: actions/checkout@v3
@@ -160,7 +159,7 @@ jobs:
           shell: /bin/sh
           install: |
             case ${{matrix.distro}} in 
-              ubuntu* | bullseye )
+              ubuntu*)
                 apt-get update
                 apt-get install -y curl gcc
                 ;;


### PR DESCRIPTION
This PR refactors the release CI:
- Remove the duplicate `v` from the binary filenames.
- Only build one glivbc and one musl version for Linux instead of building for multiple different distributions.
- Also run the release CI on the main branch and on manual dispatch for easier testing (uploading the binaries as artifacts instead of adding them to the release).

Example run for the changes: https://github.com/Nitrokey/nethsm-pkcs11/actions/runs/16494679812

Fixes: https://github.com/Nitrokey/nethsm-pkcs11/issues/247