### PR TITLE
ci: Use ubi8 for glibc build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,11 @@ jobs:
         include:
           - os: "alpine:3.18"
             name: musl
-          - os: "ubuntu:22.04"
+          - os: redhat/ubi8
             name: glibc
 
     env:
       FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-x86_64-${{ matrix.name }}.so
-      HOME: /root
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -110,13 +109,13 @@ jobs:
       - name: install dependencies
         run: |
           case ${{matrix.os}} in 
-            ubuntu*)
-              apt-get update
-              apt-get install -y curl gcc
+            redhat/ubi8*)
+              dnf install -y curl gcc
               ;;
             alpine*)
               apk add curl musl-dev gcc 
               echo RUSTFLAGS="-C target-feature=-crt-static" >> $GITHUB_ENV
+              echo HOME=/root >> $GITHUB_ENV
               ;;
           esac
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Build Linux x86_64 binary against glibc v2.28
+
 ## [1.7.1][] (2025-07-04)
 
 - Fix PKCS#1v1.5 RSA signature prefix ([#246][])


### PR DESCRIPTION
This makes the glibc binary compatible with glibc 2.28, for example used by RHEL8.