### PR TITLE
Rename Linux binaries and release v1.7.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
             name: glibc
 
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-x86_64-${{ matrix.name }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-x86_64-linux-${{ matrix.name }}.so
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -168,7 +168,7 @@ jobs:
             name: glibc
 
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-x86_64-${{ matrix.name }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-x86_64-linux-${{ matrix.name }}.so
 
     services:
       nethsm:
@@ -221,7 +221,7 @@ jobs:
           #   distro: ubuntu22.04
           #   target: riscv64gc-unknown-linux-gnu
     env:
-      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-${{ matrix.arch }}-${{ matrix.name }}.so
+      FILE_NAME: nethsm-pkcs11-${{ github.ref_name }}-${{ matrix.arch }}-linux-${{ matrix.name }}.so
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 ## Unreleased
 
+-
+
+## [1.7.2][] (2025-07-25)
+
 - Build Linux x86_64 binary against glibc v2.28
+
+[1.7.2]: https://github.com/Nitrokey/nethsm-pkcs11/releases/tag/v1.7.2
+[Full Changelog](https://github.com/Nitrokey/nethsm-pkcs11/compare/v1.7.1...v1.7.2)
 
 ## [1.7.1][] (2025-07-04)
 
 - Fix PKCS#1v1.5 RSA signature prefix ([#246][])
 
 [#246]: https://github.com/Nitrokey/nethsm-pkcs11/pull/246
+
+[1.7.1]: https://github.com/Nitrokey/nethsm-pkcs11/releases/tag/v1.7.1
+[Full Changelog](https://github.com/Nitrokey/nethsm-pkcs11/compare/v1.7.0...v1.7.1)
 
 
 ## [1.7.0][] (2025-03-17)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "nethsm_pkcs11"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "arc-swap",
  "base64ct",

--- a/pkcs11/Cargo.toml
+++ b/pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nethsm_pkcs11"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
This PR adds `-linux` to the name of the glibc and musl binaries to make it easier to identify the correct file and releases v1.7.2.