### PR TITLE
Add Windows version info to windows library builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  WINDOWS_SDK_VERSION: "10.0.26100.0"
+
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -27,7 +30,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build project
-        run: cargo build --release
+        env:
+          WINDOWS_SDK_BIN_PATH: "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\${{ env.WINDOWS_SDK_VERSION }}\\x64"
+          WINDOWS_SDK_INCLUDE_BASE_PATH: "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\${{ env.WINDOWS_SDK_VERSION }}"
+        run: |
+          $Env:PATH += ";" + "$Env:WINDOWS_SDK_BIN_PATH"
+          $Env:INCLUDE += ";" + "$Env:WINDOWS_SDK_INCLUDE_BASE_PATH\um"
+          $Env:INCLUDE += ";" + "$Env:WINDOWS_SDK_INCLUDE_BASE_PATH\shared"
+          cargo build --release
 
       - name: rename file
         run: mv -Verbose target/release/nethsm_pkcs11.dll ${{ env.FILE_NAME }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  WINDOWS_SDK_VERSION: "10.0.26100.0"
+
 jobs:
   check-formatting-linting:
     permissions:
@@ -54,7 +57,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build project
-        run: cargo build --release
+        env:
+          WINDOWS_SDK_BIN_PATH: "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\${{ env.WINDOWS_SDK_VERSION }}\\x64"
+          WINDOWS_SDK_INCLUDE_BASE_PATH: "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\${{ env.WINDOWS_SDK_VERSION }}"
+        run: |
+          $Env:PATH += ";" + "$Env:WINDOWS_SDK_BIN_PATH"
+          $Env:INCLUDE += ";" + "$Env:WINDOWS_SDK_INCLUDE_BASE_PATH\um"
+          $Env:INCLUDE += ";" + "$Env:WINDOWS_SDK_INCLUDE_BASE_PATH\shared"
+          cargo build --release
 
       - name: Archive Artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- Add Windows version information for builds in the GitHub pipeline.
 
 ## [2.1.0-rc.2][] (2026-02-17)
 

--- a/pkcs11/build.rs
+++ b/pkcs11/build.rs
@@ -1,0 +1,91 @@
+use std::{env, fs::File, io::Write, path::Path, process::Command, str::FromStr};
+
+fn main() {
+    if cfg!(target_os = "windows") {
+        versioninfo();
+    }
+}
+
+const RC_FILENAME: &str = "version.rc";
+const RES_FILENAME: &str = "version.res";
+const RC_TEMPLATE: &str = r##"
+#include <windows.h>
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     0,0,0,0
+PRODUCTVERSION  {PRODUCT_VERSION}
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       {FILEFLAGS}
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"  // US English, ANSI Latin 1; Western European (Windows)
+        BEGIN
+            VALUE "CompanyName",      "Nitrokey GmbH"
+            VALUE "FileDescription",  "PKCS#11 module for the Nitrokey NetHSM"
+            VALUE "FileVersion",      "0.0.0.0\0"
+            VALUE "ProductVersion",   "{PRODUCT_VERSION_STR}\0"
+            VALUE "InternalName",     "nethsm_pkcs11"
+            VALUE "LegalCopyright",   "Nitrokey GmbH and contributors"
+            VALUE "OriginalFilename", "nethsm_pkcs11.dll"
+            VALUE "ProductName",      "NetHSM PKCS#11 module"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1252  // US English, ANSI Latin 1; Western European (Windows)
+    END
+END"##;
+
+fn versioninfo() {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let rc_path = Path::new(&out_dir).join(RC_FILENAME);
+    let res_path = Path::new(&out_dir).join(RES_FILENAME);
+
+    let major =
+        u16::from_str(env!("CARGO_PKG_VERSION_MAJOR")).expect("Can not parse major to u16.");
+    let minor =
+        u16::from_str(env!("CARGO_PKG_VERSION_MINOR")).expect("Can not parse minor to u16.");
+    let patch =
+        u16::from_str(env!("CARGO_PKG_VERSION_PATCH")).expect("Can not parse patch to u16.");
+    let pre = env!("CARGO_PKG_VERSION_PRE");
+
+    let fileflags = if pre.is_empty() {
+        "0x0"
+    } else {
+        "VS_FF_PRERELEASE"
+    };
+
+    let resource_script = String::from(RC_TEMPLATE)
+        .replace(
+            "{PRODUCT_VERSION}",
+            &format!("{},{},{},{}", major, minor, patch, 0),
+        )
+        .replace("{PRODUCT_VERSION_STR}", env!("CARGO_PKG_VERSION"))
+        .replace("{FILEFLAGS}", fileflags);
+
+    let mut f = File::create(rc_path.to_str().unwrap()).unwrap();
+    f.write_all(resource_script.as_bytes())
+        .expect("Could not write resource script.");
+
+    let output = Command::new("rc")
+        .args(["/fo", res_path.to_str().unwrap(), rc_path.to_str().unwrap()])
+        .output()
+        .expect("Failed to run resource compiler. Make sure the Windows Software Development Kit (SDK) is installed and available in the Path environment variable.");
+
+    if !output.status.success() {
+        panic!(
+            "Resource compilation failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // Only run for release events in the GitHub pipeline
+    if env::var("GITHUB_EVENT_NAME").unwrap_or_default() == "release" {
+        println!("cargo:rustc-link-arg={}", res_path.to_str().unwrap());
+        println!("cargo:rerun-if-changed=Cargo.toml");
+    }
+}


### PR DESCRIPTION
This PR adds the version info to Windows builds of the library.

Version information on Windows get defined in resource scripts (`*.rc`). They get compiled to a resource file (`*.res`) with the *rc* compiler and linked into the binary.
Such resource scripts contain four version fields: `PRODUCTVERSION`, `PRODUCTVERSION_STR`, `FILEVERSION`, and `FILEVERSION_STR`. For this library we can ignore the `FILEVERSION`. This would only be relevant if this library is versioned differently in the context of a product suite. The field `PRODUCTVERSION`, accepts a version number with four fields, e.g. `A.B.C.D` (each is a `u16`). The `PRODUCTVERSION_STR` accepts a string.

The build script in `build.rs` contains a template of such a resource script. The version is filled in depending on the version value in `Cargo.toml`. This version value is in the SemVer format and doesn't match 1:1 to the Windows version info. Hence, we make an opinionated match.

`A.B.C` -> `A.B.C.0`
`A.B.C-rc` -> `A.B.C.0` and the `FILEFLAGS` is set to `VS_FF_PRERELEASE`
`A.B.C-rc.1` -> `A.B.C.0` and the `FILEFLAGS` is set to `VS_FF_PRERELEASE`

If the `MAJOR`, `MINOR`, or `PATCH` fields in the SemVer format can't be parsed to an `u16` the build script will fail. The `PRODUCTVERSION_STR` field will always be set to the SemVer value.

The creation, compilation, and linking of the resource file is conditional. For the creation and compilation, the condition checks if the build process runs on Windows. The condition for linking checks if the `GITHUB_EVENT_NAME` environment variable is set to `release`. The condition on the release event is to exclude version information from test builds in the CI. Hence, they will be easier distinguishable: normal CI build -> version information absent, release build -> version information present.

Fixes: #256