### PR TITLE
Fix mismatched lifetime syntax

### DIFF
--- a/pkcs11/src/backend/db/attr.rs
+++ b/pkcs11/src/backend/db/attr.rs
@@ -117,7 +117,7 @@ impl CkRawAttrTemplate {
         self.count
     }
 
-    pub fn iter(&self) -> CkRawAttrTemplateIter {
+    pub fn iter(&self) -> CkRawAttrTemplateIter<'_> {
         CkRawAttrTemplateIter {
             tpl: self,
             index: 0,


### PR DESCRIPTION
This fixes a new clippy lint, mismatched_lifetime_syntaxes.