### PR TITLE
Update cache after deleting keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for EC_P256K1, BrainpoolP256, BrainpoolP384 and BrainpoolP512 keys
 - Remove `enable_set_attribute_value` config option
 - Implement `C_SetAttributeValue` for `CKA_ID` to support renaming keys
+- Remove corresponding certificate and public key objects from the cache if a private key is deleted ([#260](https://github.com/Nitrokey/nethsm-pkcs11/issues/260))
 
 ## [1.7.2][] (2025-07-25)
 

--- a/pkcs11/src/backend/db/mod.rs
+++ b/pkcs11/src/backend/db/mod.rs
@@ -112,6 +112,10 @@ impl Db {
             }
         }
     }
+
+    pub fn remove_objects_by_id(&mut self, id: &str) {
+        self.objects.retain(|_, object| object.id != id)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When a key is deleted on the NetHSM by calling C_DestroyObject for a private key object, the corresponding public key and certificate objects become invalid. With this patch, we remove these invalid objects from the cache used by the pkcs11 module.

Fixes: https://github.com/Nitrokey/nethsm-pkcs11/issues/260