### PR TITLE
api: Use wrappers for stateful API functions

### DIFF
--- a/pkcs11/src/api/sign.rs
+++ b/pkcs11/src/api/sign.rs
@@ -5,6 +5,7 @@ use crate::{
     api::api_function,
     backend::{
         mechanism::{CkRawMechanism, Mechanism},
+        session::Session,
         Pkcs11Error,
     },
     data,
@@ -56,13 +57,38 @@ fn sign(
 ) -> Result<(), Pkcs11Error> {
     let session = data::get_session(session)?;
     let mut session = data::lock_session(&session)?;
+    let result = sign_impl(
+        &mut session,
+        data_ptr,
+        data_len,
+        signature_ptr,
+        signature_len_ptr,
+    );
 
+    // A call to C_Sign always terminates the active signing operation unless it returns
+    // CKR_BUFFER_TOO_SMALL or is a successful call (i.e., one which returns CKR_OK) to determine
+    // the length of the buffer needed to hold the signature.
+    let is_buffer_too_small = result == Err(Pkcs11Error::BufferTooSmall);
+    let is_buffer_size_query = result.is_ok() && signature_ptr.is_null();
+    if !(is_buffer_too_small || is_buffer_size_query) {
+        session.sign_clear();
+    }
+
+    result
+}
+
+fn sign_impl(
+    session: &mut Session,
+    data_ptr: *mut cryptoki_sys::CK_BYTE,
+    data_len: cryptoki_sys::CK_ULONG,
+    signature_ptr: *mut cryptoki_sys::CK_BYTE,
+    signature_len_ptr: *mut cryptoki_sys::CK_ULONG,
+) -> Result<(), Pkcs11Error> {
     trace!("pData null {}", data_ptr.is_null());
     trace!("pulSignatureLen null {}", signature_len_ptr.is_null());
 
     if data_ptr.is_null() || signature_len_ptr.is_null() {
         trace!("aborting sign due to null");
-        session.sign_clear();
         return Err(Pkcs11Error::ArgumentsBad);
     }
 
@@ -70,9 +96,7 @@ fn sign(
 
     let buffer_size = unsafe { *signature_len_ptr } as usize;
 
-    let theoretical_size = session
-        .sign_theoretical_size()
-        .inspect_err(|_| session.sign_clear())?;
+    let theoretical_size = session.sign_theoretical_size()?;
 
     unsafe {
         std::ptr::write(signature_len_ptr, theoretical_size as CK_ULONG);
@@ -89,7 +113,7 @@ fn sign(
         return Err(Pkcs11Error::BufferTooSmall);
     }
 
-    let signature = session.sign(data).inspect_err(|_| session.sign_clear())?;
+    let signature = session.sign(data)?;
     unsafe {
         std::ptr::write(signature_len_ptr, signature.len() as CK_ULONG);
     }
@@ -103,8 +127,6 @@ fn sign(
     unsafe {
         std::ptr::copy_nonoverlapping(signature.as_ptr(), signature_ptr, signature.len());
     }
-
-    session.sign_clear();
 
     Ok(())
 }
@@ -123,18 +145,28 @@ fn sign_update(
 ) -> Result<(), Pkcs11Error> {
     let session = data::get_session(session)?;
     let mut session = data::lock_session(&session)?;
+    let result = sign_update_impl(&mut session, part_ptr, part_len);
 
-    if part_ptr.is_null() {
+    // A call to C_SignUpdate which results in an error terminates the current signature operation.
+    if result.is_err() {
         session.sign_clear();
+    }
+
+    result
+}
+
+fn sign_update_impl(
+    session: &mut Session,
+    part_ptr: *mut cryptoki_sys::CK_BYTE,
+    part_len: cryptoki_sys::CK_ULONG,
+) -> Result<(), Pkcs11Error> {
+    if part_ptr.is_null() {
         return Err(Pkcs11Error::ArgumentsBad);
     }
 
     let part = unsafe { std::slice::from_raw_parts(part_ptr, part_len as usize) };
 
-    session.sign_update(part).map_err(|err| {
-        session.sign_clear();
-        err.into()
-    })
+    session.sign_update(part).map_err(From::from)
 }
 
 api_function!(
@@ -151,17 +183,32 @@ fn sign_final(
 ) -> Result<(), Pkcs11Error> {
     let session = data::get_session(session)?;
     let mut session = data::lock_session(&session)?;
+    let result = sign_final_impl(&mut session, signature_ptr, signature_len_ptr);
 
-    if signature_len_ptr.is_null() {
+    // A call to C_SignFinal always terminates the active signing operation unless it returns
+    // CKR_BUFFER_TOO_SMALL or is a successful call (i.e., one which returns CKR_OK) to determine
+    // the length of the buffer needed to hold the signature.
+    let is_buffer_too_small = result == Err(Pkcs11Error::BufferTooSmall);
+    let is_buffer_size_query = result.is_ok() && signature_ptr.is_null();
+    if !(is_buffer_too_small || is_buffer_size_query) {
         session.sign_clear();
+    }
+
+    result
+}
+
+fn sign_final_impl(
+    session: &mut Session,
+    signature_ptr: *mut cryptoki_sys::CK_BYTE,
+    signature_len_ptr: *mut cryptoki_sys::CK_ULONG,
+) -> Result<(), Pkcs11Error> {
+    if signature_len_ptr.is_null() {
         return Err(Pkcs11Error::ArgumentsBad);
     }
 
     let buffer_size = unsafe { *signature_len_ptr } as usize;
 
-    let theoretical_size = session
-        .sign_theoretical_size()
-        .inspect_err(|_| session.sign_clear())?;
+    let theoretical_size = session.sign_theoretical_size()?;
 
     unsafe {
         std::ptr::write(signature_len_ptr, theoretical_size as CK_ULONG);
@@ -176,7 +223,7 @@ fn sign_final(
         return Err(Pkcs11Error::BufferTooSmall);
     }
 
-    let signature = session.sign_final().inspect_err(|_| session.sign_clear())?;
+    let signature = session.sign_final()?;
 
     unsafe {
         std::ptr::write(signature_len_ptr, signature.len() as CK_ULONG);
@@ -191,7 +238,6 @@ fn sign_final(
     unsafe {
         std::ptr::copy_nonoverlapping(signature.as_ptr(), signature_ptr, signature.len());
     }
-    session.sign_clear();
 
     Ok(())
 }

--- a/pkcs11/src/backend/mod.rs
+++ b/pkcs11/src/backend/mod.rs
@@ -49,7 +49,7 @@ macro_rules! pkcs11_error {
 }
 
 pkcs11_error! {
-    #[derive(Clone, Copy, Debug)]
+    #[derive(Clone, Copy, Debug, PartialEq)]
     pub enum Pkcs11Error {
         ActionProhibited = cryptoki_sys::CKR_ACTION_PROHIBITED,
         ArgumentsBad = cryptoki_sys::CKR_ARGUMENTS_BAD,


### PR DESCRIPTION
The decrypt, encrypt and sign API functions maintain state that has to be cleared after function calls depending on the result of the function call. Currently, this is implemented manually on every possible return path, but that is hard to maintain and check. This patch introduces wrapper functions that clear the state depending on the result of the actual implementation and according to the requirements of the specification.