### PR TITLE
Unpin docker image for CI

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -104,7 +104,7 @@ jobs:
 
     services:
       nethsm:
-        image: nitrokey/nethsm:3e45f2f3
+        image: nitrokey/nethsm:testing
         ports:
           - 8443:8443
     steps:


### PR DESCRIPTION
The module has been updated for the P224 removal so we can go back to using the latest testing image.