### PR TITLE
Fix panic if too many instances are unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
--
+### Bugfixes
+
+- Fix panic if multiple instances are configured and too many instances become unavailable ([#313](https://github.com/Nitrokey/nethsm-pkcs11/issues/313))
 
 ## [2.1.0][] (2026-02-27)
 

--- a/pkcs11/src/backend/login.rs
+++ b/pkcs11/src/backend/login.rs
@@ -227,33 +227,26 @@ impl LoginCtx {
         accept_health_check: HealthCheck,
     ) -> (&InstanceData, ShouldHealthCheck) {
         let threads_allowed = THREADS_ALLOWED.load(Relaxed);
-        let index = self.slot.instance_balancer.fetch_add(1, Relaxed);
-        let index = index % self.slot.instances.len();
-        let instance = &self.slot.instances[index];
-        match (instance.should_try(), threads_allowed, accept_health_check) {
-            (InstanceAttempt::Failed, _, _)
-            | (InstanceAttempt::Retry, true, _)
-            | (InstanceAttempt::Retry, false, HealthCheck::Avoid) => {}
-            (InstanceAttempt::Working, _, _) => return (instance, ShouldHealthCheck::RunDirectly),
-            (InstanceAttempt::Retry, false, HealthCheck::Possible) => {
-                return (instance, ShouldHealthCheck::HealthCheckFirst)
-            }
-        }
-        for i in 0..self.slot.instances.len() - 1 {
-            let instance = &self.slot.instances[index + i];
-
+        let index = self.slot.instance_balancer.load(Relaxed);
+        let (head, tail) = self
+            .slot
+            .instances
+            .split_at((index + 1) % self.slot.instances.len());
+        for (i, instance) in tail.iter().chain(head).enumerate() {
+            // we split at index + 1, so we need to add i + 1 to the old index
+            let i = i + 1;
             match (instance.should_try(), threads_allowed, accept_health_check) {
                 (InstanceAttempt::Failed, _, _)
                 | (InstanceAttempt::Retry, true, _)
                 | (InstanceAttempt::Retry, false, HealthCheck::Avoid) => continue,
                 (InstanceAttempt::Working, _, _) => {
-                    // This not true round-robin in case of multithreaded acces
+                    // This not true round-robin in case of multithreaded access
                     // This is degraded mode so best-effort is attempted at best
                     self.slot.instance_balancer.fetch_add(i, Relaxed);
                     return (instance, ShouldHealthCheck::RunDirectly);
                 }
                 (InstanceAttempt::Retry, false, HealthCheck::Possible) => {
-                    // This not true round-robin in case of multithreaded acces
+                    // This not true round-robin in case of multithreaded access
                     // This is degraded mode so best-effort is attempted at best
                     self.slot.instance_balancer.fetch_add(i, Relaxed);
                     return (instance, ShouldHealthCheck::HealthCheckFirst);

--- a/tools/tests/p11nethsm.unreachable.conf
+++ b/tools/tests/p11nethsm.unreachable.conf
@@ -1,0 +1,25 @@
+# log_file: /tmp/p11nethsm.log
+# log_level: Trace
+slots:
+  - label: LocalHSM
+    description: Local HSM (docker)
+    operator:
+      username: "operator"
+      password: "opPassphrase"
+    administrator:
+      username: "admin"
+      password: "Administrator"
+    instances:
+      - url: "https://localhost:9999/api/v1"
+        max_idle_connections: 16
+        danger_insecure_cert: true
+      - url: "https://localhost:9998/api/v1"
+        max_idle_connections: 16
+        danger_insecure_cert: true
+      - url: "https://localhost:9998/api/v1"
+        max_idle_connections: 16
+        danger_insecure_cert: true
+    retries: 
+      count: 1
+      delay_seconds: 1
+    timeout_seconds: 10

--- a/tools/tests/unreachable_instances.sh
+++ b/tools/tests/unreachable_instances.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -x
+
+set -e
+
+export P11NETHSM_CONFIG_FILE=./tools/tests/p11nethsm.unreachable.conf
+
+output=$(pkcs11-tool --module ./target/debug/libnethsm_pkcs11.so -O 2>&1 || true)
+echo "$output"
+
+! grep --quiet panic <<< "$output"
+grep --quiet "No slot with a token was found" <<< "$output"


### PR DESCRIPTION
This fixes a regression from https://github.com/Nitrokey/nethsm-pkcs11/pull/218: The current implementation does not calculate the index correctly when looping over the available instances. This can be fixed by replacing the index with an iterator. The old loop also skipped the last instance because ranges are exclusive, so `for i in 0..self.slot.instances.len() - 1` yields values with `i < self.slot.instances.len() - 1`. I think this was an oversight and fixed it with this PR.

Fixes: https://github.com/Nitrokey/nethsm-pkcs11/issues/313