### PR TITLE
Disable rayon threading on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 
 - Fix panic if multiple instances are configured and too many instances become unavailable ([#313](https://github.com/Nitrokey/nethsm-pkcs11/issues/313))
+- Temporarily disable parallel key listing on Windows.
 
 ## [2.1.0][] (2026-02-27)
 

--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -561,16 +561,17 @@ impl Session {
             )?
             .entity;
 
-        let results: Result<Vec<Vec<Object>>, _> = if THREADS_ALLOWED.load(Ordering::Relaxed) {
-            use rayon::prelude::*;
-            keys.par_iter()
-                .map(|k| super::key::fetch_one(k, &self.login_ctx, None))
-                .collect()
-        } else {
-            keys.iter()
-                .map(|k| super::key::fetch_one(k, &self.login_ctx, None))
-                .collect()
-        };
+        let results: Result<Vec<Vec<Object>>, _> =
+            if THREADS_ALLOWED.load(Ordering::Relaxed) && cfg!(not(target_os = "windows")) {
+                use rayon::prelude::*;
+                keys.par_iter()
+                    .map(|k| super::key::fetch_one(k, &self.login_ctx, None))
+                    .collect()
+            } else {
+                keys.iter()
+                    .map(|k| super::key::fetch_one(k, &self.login_ctx, None))
+                    .collect()
+            };
 
         let results = results?;
 


### PR DESCRIPTION
It has been found that in the current implementation the *rayon* thread pool doesn't terminate its spawned threads in time. This causes in some case a crash of the library on Windows (access violation exception) when the threads later wake up and try to access freed memory.

This PR disables the parallel operation with *rayon* on Windows, until a solution is found.