### PR TITLE
Fix argument handling in C_Initialize and add thread config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fix panic if multiple instances are configured and too many instances become unavailable ([#313](https://github.com/Nitrokey/nethsm-pkcs11/issues/313))
 - Temporarily disable parallel key listing on Windows.
+- Fix argument handling in `C_Initialize`:
+  - Remove unnecessary version check so that the argument is handled at all.
+  - Correctly handle `null` arguments and initialize the thread state consistently.
+  - Return an error if some but not all of the `CreateMutex`, `DestroyMutex`, `LockMutex` and `UnlockMutex` fields are set.
 
 ## [2.1.0][] (2026-02-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+### Features
+
+- Add `disable_threads` and `disable_thread_pool` config options
+
 ### Bugfixes
 
 - Fix panic if multiple instances are configured and too many instances become unavailable ([#313](https://github.com/Nitrokey/nethsm-pkcs11/issues/313))
-- Temporarily disable parallel key listing on Windows.
 - Fix argument handling in `C_Initialize`:
   - Remove unnecessary version check so that the argument is handled at all.
   - Correctly handle `null` arguments and initialize the thread state consistently.

--- a/p11nethsm.example.conf
+++ b/p11nethsm.example.conf
@@ -22,6 +22,12 @@ syslog_facility: "user"
 # You can also configure a custom file, or "-" for stderr.
 # log_file: /tmp/p11nethsm.log
 
+# The following options can be used to configure if the pkcs11 module can spawn threads to speed up operations.
+# This option has the same effect as setting the CKF_LIBRARY_CANT_CREATE_OS_THREADS flag in C_Initialize, i. e. it disables all uses of threads.
+# disable_threads: true
+# This option only disables the use of thread pools which can cause problems if the library is unloaded.
+# disable_thread_pool: true
+
 # Each "slot" represents a HSM cluster of server that share the same user and keys.
 slots:
   - label: LocalHSM                        # Name your NetHSM however you want

--- a/pkcs11/config_file/src/lib.rs
+++ b/pkcs11/config_file/src/lib.rs
@@ -125,6 +125,10 @@ pub struct P11Config {
     pub log_level: Option<LogLevel>,
     #[merge(strategy = merge::vec::append)]
     pub slots: Vec<SlotConfig>,
+    #[merge(strategy = merge::option::overwrite_none)]
+    pub disable_threads: Option<bool>,
+    #[merge(strategy = merge::option::overwrite_none)]
+    pub disable_thread_pool: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -388,6 +392,8 @@ password: ""
                 syslog_process: None,
                 log_file: None,
                 log_level: Some(LogLevel::Debug),
+                disable_threads: None,
+                disable_thread_pool: None,
                 slots: vec![SlotConfig {
                     label: "LocalHSM".into(),
                     description: Some("Local HSM (docker)".into()),

--- a/pkcs11/src/api/mod.rs
+++ b/pkcs11/src/api/mod.rs
@@ -90,36 +90,47 @@ fn initialize(init_args_ptr: CK_VOID_PTR) -> Result<(), Pkcs11Error> {
         debug!("No slots configured");
     }
 
-    if defs::CRYPTOKI_VERSION.major == 2
-        && defs::CRYPTOKI_VERSION.minor == 40
-        && !init_args_ptr.is_null()
-    {
+    let mut disable_threads = false;
+
+    if !init_args_ptr.is_null() {
         let args = init_args_ptr as cryptoki_sys::CK_C_INITIALIZE_ARGS_PTR;
         let args = unsafe { std::ptr::read(args) };
 
-        // for cryptoki 2.40 this should always be null
-        if !(args).pReserved.is_null() {
+        if !args.pReserved.is_null() {
             return Err(Pkcs11Error::ArgumentsBad);
         }
 
         let flags = args.flags;
-        let create_mutex = args.CreateMutex;
+        let mutex_fields = [
+            args.CreateMutex.is_some(),
+            args.DestroyMutex.is_some(),
+            args.LockMutex.is_some(),
+            args.UnlockMutex.is_some(),
+        ];
 
         trace!("C_Initialize() called with flags: {flags:?}");
-        trace!("C_Initialize() called with CreateMutex: {create_mutex:?}");
+        trace!("C_Initialize() called with Create/Destroy/Lock/UnlockMutex: {mutex_fields:?}");
+
+        // Either all or none of the mutex fields must be set
+        let mutex_fields_set = mutex_fields.iter().any(|b| *b);
+        if mutex_fields_set && mutex_fields.iter().any(|b| !b) {
+            return Err(Pkcs11Error::ArgumentsBad);
+        }
 
         // currently we don't support custom locking
         // if the flag is not set and the mutex functions are not null, the program asks us to use only the mutex functions, we can't do that
-        if flags & cryptoki_sys::CKF_OS_LOCKING_OK == 0 && create_mutex.is_some() {
+        if flags & cryptoki_sys::CKF_OS_LOCKING_OK == 0 && mutex_fields_set {
             return Err(Pkcs11Error::CantLock);
         }
 
         if flags & cryptoki_sys::CKF_LIBRARY_CANT_CREATE_OS_THREADS != 0 {
-            THREADS_ALLOWED.store(false, Ordering::Relaxed);
-        } else {
-            THREADS_ALLOWED.store(true, Ordering::Relaxed);
-            start_background_timer();
+            disable_threads = true;
         }
+    }
+
+    THREADS_ALLOWED.store(!disable_threads, Ordering::Relaxed);
+    if !disable_threads {
+        start_background_timer();
     }
 
     // Initialize the events manager
@@ -188,8 +199,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
     fn test_init_finalize() {
         let _guard = init_lock();
 
@@ -221,8 +230,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
     fn test_init_args_reserved() {
         let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
             CreateMutex: None,
@@ -238,8 +245,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
     fn test_init_args_no_threads() {
         let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
             CreateMutex: None,
@@ -256,8 +261,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
     fn test_init_args_bad_callbacks() {
         let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
             CreateMutex: Some(mutex_callback),
@@ -273,8 +276,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
     fn test_init_args_case_1() {
         let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
             CreateMutex: None,
@@ -291,8 +292,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
     fn test_init_args_case_2() {
         let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
             CreateMutex: None,
@@ -309,8 +308,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
     fn test_init_args_case_3() {
         let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
             CreateMutex: Some(mutex_callback),
@@ -326,8 +323,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
     fn test_init_args_case_4() {
         let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
             CreateMutex: Some(mutex_callback),

--- a/pkcs11/src/api/mod.rs
+++ b/pkcs11/src/api/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         events::{fetch_slots_state, EventsManager},
         Pkcs11Error,
     },
-    data::{self, DEVICE, EVENTS_MANAGER, THREADS_ALLOWED, TOKENS_STATE},
+    data::{self, DEVICE, EVENTS_MANAGER, THREADS_ALLOWED, THREAD_POOL_ALLOWED, TOKENS_STATE},
     defs,
     utils::padded_str,
 };
@@ -78,7 +78,7 @@ api_function!(
 );
 
 fn initialize(init_args_ptr: CK_VOID_PTR) -> Result<(), Pkcs11Error> {
-    let device = crate::config::initialization::initialize().map_err(|err| {
+    let (device, config) = crate::config::initialization::initialize().map_err(|err| {
         error!("NetHSM PKCS#11: Failed to initialize configuration: {err}");
         Pkcs11Error::FunctionFailed
     })?;
@@ -90,7 +90,8 @@ fn initialize(init_args_ptr: CK_VOID_PTR) -> Result<(), Pkcs11Error> {
         debug!("No slots configured");
     }
 
-    let mut disable_threads = false;
+    let mut disable_threads = config.disable_threads.unwrap_or(false);
+    let disable_thread_pool = config.disable_thread_pool.unwrap_or(false);
 
     if !init_args_ptr.is_null() {
         let args = init_args_ptr as cryptoki_sys::CK_C_INITIALIZE_ARGS_PTR;
@@ -101,11 +102,15 @@ fn initialize(init_args_ptr: CK_VOID_PTR) -> Result<(), Pkcs11Error> {
         }
 
         let flags = args.flags;
+        let create_mutex = args.CreateMutex;
+        let destroy_mutex = args.DestroyMutex;
+        let lock_mutex = args.LockMutex;
+        let unlock_mutex = args.UnlockMutex;
         let mutex_fields = [
-            args.CreateMutex.is_some(),
-            args.DestroyMutex.is_some(),
-            args.LockMutex.is_some(),
-            args.UnlockMutex.is_some(),
+            create_mutex.is_some(),
+            destroy_mutex.is_some(),
+            lock_mutex.is_some(),
+            unlock_mutex.is_some(),
         ];
 
         trace!("C_Initialize() called with flags: {flags:?}");
@@ -122,13 +127,13 @@ fn initialize(init_args_ptr: CK_VOID_PTR) -> Result<(), Pkcs11Error> {
         if flags & cryptoki_sys::CKF_OS_LOCKING_OK == 0 && mutex_fields_set {
             return Err(Pkcs11Error::CantLock);
         }
-
         if flags & cryptoki_sys::CKF_LIBRARY_CANT_CREATE_OS_THREADS != 0 {
             disable_threads = true;
         }
     }
 
     THREADS_ALLOWED.store(!disable_threads, Ordering::Relaxed);
+    THREAD_POOL_ALLOWED.store(!disable_threads && !disable_thread_pool, Ordering::Relaxed);
     if !disable_threads {
         start_background_timer();
     }
@@ -188,6 +193,7 @@ mod test {
     fn assert_initialized(threads_allowed: bool) {
         assert!(DEVICE.load_full().is_some());
         assert_eq!(THREADS_ALLOWED.load(Ordering::Relaxed), threads_allowed);
+        assert_eq!(THREAD_POOL_ALLOWED.load(Ordering::Relaxed), threads_allowed);
         assert_eq!(RETRY_THREAD.read().unwrap().is_some(), threads_allowed);
         assert!(!EVENTS_MANAGER.read().unwrap().finalized);
     }

--- a/pkcs11/src/api/mod.rs
+++ b/pkcs11/src/api/mod.rs
@@ -170,7 +170,226 @@ fn get_info(info_ptr: CK_INFO_PTR) -> Result<(), Pkcs11Error> {
 
 #[cfg(test)]
 mod test {
+    use crate::{backend::slot::init_lock, config::device::RETRY_THREAD};
+
     use super::*;
+
+    fn assert_initialized(threads_allowed: bool) {
+        assert!(DEVICE.load_full().is_some());
+        assert_eq!(THREADS_ALLOWED.load(Ordering::Relaxed), threads_allowed);
+        assert_eq!(RETRY_THREAD.read().unwrap().is_some(), threads_allowed);
+        assert!(!EVENTS_MANAGER.read().unwrap().finalized);
+    }
+
+    fn assert_uninitialized() {
+        assert!(DEVICE.load_full().is_none());
+        assert!(RETRY_THREAD.read().unwrap().is_none());
+        assert!(EVENTS_MANAGER.read().unwrap().finalized);
+    }
+
+    #[test]
+    #[ignore]
+    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
+    fn test_init_finalize() {
+        let _guard = init_lock();
+
+        let rv = C_Initialize(std::ptr::null_mut());
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+        assert_initialized(true);
+
+        let rv = C_Finalize(std::ptr::null_mut());
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+        assert_uninitialized();
+    }
+
+    fn init_with_args<F: FnOnce(cryptoki_sys::CK_RV)>(
+        mut args: cryptoki_sys::CK_C_INITIALIZE_ARGS,
+        callback: F,
+    ) {
+        let _guard = init_lock();
+        let args_ptr: cryptoki_sys::CK_C_INITIALIZE_ARGS_PTR = &mut args;
+        let rv = C_Initialize(args_ptr as _);
+        callback(rv);
+        if rv == cryptoki_sys::CKR_OK {
+            let rv = C_Finalize(std::ptr::null_mut());
+            assert_eq!(rv, cryptoki_sys::CKR_OK);
+        }
+    }
+
+    unsafe extern "C" fn mutex_callback<T>(_arg1: T) -> cryptoki_sys::CK_RV {
+        cryptoki_sys::CKR_FUNCTION_NOT_SUPPORTED
+    }
+
+    #[test]
+    #[ignore]
+    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
+    fn test_init_args_reserved() {
+        let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
+            CreateMutex: None,
+            DestroyMutex: None,
+            LockMutex: None,
+            UnlockMutex: None,
+            flags: 0,
+            pReserved: "test".as_ptr() as _,
+        };
+        init_with_args(args, |rv| {
+            assert_eq!(rv, cryptoki_sys::CKR_ARGUMENTS_BAD);
+        });
+    }
+
+    #[test]
+    #[ignore]
+    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
+    fn test_init_args_no_threads() {
+        let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
+            CreateMutex: None,
+            DestroyMutex: None,
+            LockMutex: None,
+            UnlockMutex: None,
+            flags: cryptoki_sys::CKF_LIBRARY_CANT_CREATE_OS_THREADS,
+            pReserved: std::ptr::null_mut(),
+        };
+        init_with_args(args, |rv| {
+            assert_eq!(rv, cryptoki_sys::CKR_OK);
+            assert_initialized(false);
+        });
+    }
+
+    #[test]
+    #[ignore]
+    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
+    fn test_init_args_bad_callbacks() {
+        let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
+            CreateMutex: Some(mutex_callback),
+            DestroyMutex: None,
+            LockMutex: None,
+            UnlockMutex: None,
+            flags: 0,
+            pReserved: std::ptr::null_mut(),
+        };
+        init_with_args(args, |rv| {
+            assert_eq!(rv, cryptoki_sys::CKR_ARGUMENTS_BAD);
+        });
+    }
+
+    #[test]
+    #[ignore]
+    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
+    fn test_init_args_case_1() {
+        let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
+            CreateMutex: None,
+            DestroyMutex: None,
+            LockMutex: None,
+            UnlockMutex: None,
+            flags: 0,
+            pReserved: std::ptr::null_mut(),
+        };
+        init_with_args(args, |rv| {
+            assert_eq!(rv, cryptoki_sys::CKR_OK);
+            assert_initialized(true);
+        });
+    }
+
+    #[test]
+    #[ignore]
+    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
+    fn test_init_args_case_2() {
+        let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
+            CreateMutex: None,
+            DestroyMutex: None,
+            LockMutex: None,
+            UnlockMutex: None,
+            flags: cryptoki_sys::CKF_OS_LOCKING_OK,
+            pReserved: std::ptr::null_mut(),
+        };
+        init_with_args(args, |rv| {
+            assert_eq!(rv, cryptoki_sys::CKR_OK);
+            assert_initialized(true);
+        });
+    }
+
+    #[test]
+    #[ignore]
+    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
+    fn test_init_args_case_3() {
+        let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
+            CreateMutex: Some(mutex_callback),
+            DestroyMutex: Some(mutex_callback),
+            LockMutex: Some(mutex_callback),
+            UnlockMutex: Some(mutex_callback),
+            flags: 0,
+            pReserved: std::ptr::null_mut(),
+        };
+        init_with_args(args, |rv| {
+            assert_eq!(rv, cryptoki_sys::CKR_CANT_LOCK);
+        });
+    }
+
+    #[test]
+    #[ignore]
+    // https://github.com/Nitrokey/nethsm-pkcs11/issues/325
+    fn test_init_args_case_4() {
+        let args = cryptoki_sys::CK_C_INITIALIZE_ARGS {
+            CreateMutex: Some(mutex_callback),
+            DestroyMutex: Some(mutex_callback),
+            LockMutex: Some(mutex_callback),
+            UnlockMutex: Some(mutex_callback),
+            flags: cryptoki_sys::CKF_OS_LOCKING_OK,
+            pReserved: std::ptr::null_mut(),
+        };
+        init_with_args(args, |rv| {
+            assert_eq!(rv, cryptoki_sys::CKR_OK);
+            assert_initialized(true);
+        });
+    }
+
+    #[test]
+    fn test_init_twice() {
+        let _guard = init_lock();
+
+        let rv = C_Initialize(std::ptr::null_mut());
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+        let rv = C_Initialize(std::ptr::null_mut());
+        // TODO: https://github.com/Nitrokey/nethsm-pkcs11/issues/324
+        // assert_eq!(rv, cryptoki_sys::CKR_CRYPTOKI_ALREADY_INITIALIZED);
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+        let rv = C_Finalize(std::ptr::null_mut());
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+    }
+
+    #[test]
+    fn test_finalize() {
+        let _guard = init_lock();
+
+        let rv = C_Finalize(std::ptr::null_mut());
+        // TODO: https://github.com/Nitrokey/nethsm-pkcs11/issues/324
+        // assert_eq!(rv, cryptoki_sys::CKR_CRYPTOKI_NOT_INITIALIZED);
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+    }
+
+    #[test]
+    fn test_finalize_args() {
+        let _guard = init_lock();
+
+        let mut args = 0;
+        let args_ptr: *mut u8 = &mut args;
+        let rv = C_Finalize(args_ptr as _);
+        assert_eq!(rv, cryptoki_sys::CKR_ARGUMENTS_BAD);
+    }
+
+    #[test]
+    fn test_finalize_twice() {
+        let _guard = init_lock();
+
+        let rv = C_Initialize(std::ptr::null_mut());
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+        let rv = C_Finalize(std::ptr::null_mut());
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+        let rv = C_Finalize(std::ptr::null_mut());
+        // TODO: https://github.com/Nitrokey/nethsm-pkcs11/issues/324
+        // assert_eq!(rv, cryptoki_sys::CKR_CRYPTOKI_NOT_INITIALIZED);
+        assert_eq!(rv, cryptoki_sys::CKR_OK);
+    }
 
     #[test]
     fn test_get_function_list() {

--- a/pkcs11/src/backend/session.rs
+++ b/pkcs11/src/backend/session.rs
@@ -13,7 +13,7 @@ use nethsm_sdk_rs::{apis::default_api, models::MoveKeyRequest};
 use crate::{
     backend::{key::NetHSMId, login::UserMode, Error, Pkcs11Error},
     config::device::Slot,
-    data::THREADS_ALLOWED,
+    data::THREAD_POOL_ALLOWED,
 };
 
 use super::{
@@ -561,17 +561,16 @@ impl Session {
             )?
             .entity;
 
-        let results: Result<Vec<Vec<Object>>, _> =
-            if THREADS_ALLOWED.load(Ordering::Relaxed) && cfg!(not(target_os = "windows")) {
-                use rayon::prelude::*;
-                keys.par_iter()
-                    .map(|k| super::key::fetch_one(k, &self.login_ctx, None))
-                    .collect()
-            } else {
-                keys.iter()
-                    .map(|k| super::key::fetch_one(k, &self.login_ctx, None))
-                    .collect()
-            };
+        let results: Result<Vec<Vec<Object>>, _> = if THREAD_POOL_ALLOWED.load(Ordering::Relaxed) {
+            use rayon::prelude::*;
+            keys.par_iter()
+                .map(|k| super::key::fetch_one(k, &self.login_ctx, None))
+                .collect()
+        } else {
+            keys.iter()
+                .map(|k| super::key::fetch_one(k, &self.login_ctx, None))
+                .collect()
+        };
 
         let results = results?;
 
@@ -733,7 +732,7 @@ mod test {
     #[test]
     #[ignore]
     fn parrallel_fetch_all_keys_fail() {
-        THREADS_ALLOWED.store(false, Ordering::Relaxed);
+        THREAD_POOL_ALLOWED.store(false, Ordering::Relaxed);
         let _guard = init_for_tests();
         let mut slot = get_slot(0).unwrap();
         let mut sessions = Vec::new();

--- a/pkcs11/src/backend/slot.rs
+++ b/pkcs11/src/backend/slot.rs
@@ -15,17 +15,30 @@ pub fn get_slot(slot_id: CK_SLOT_ID) -> Result<Arc<Slot>, Pkcs11Error> {
 }
 
 #[cfg(test)]
-pub fn init_for_tests() -> std::sync::MutexGuard<'static, ()> {
-    use std::{ptr, sync::Mutex};
-
-    use crate::{api::C_Initialize, data::DEVICE};
+pub fn init_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, Once};
 
     static MUTEX: Mutex<()> = Mutex::new(());
+    static SET_ENV: Once = Once::new();
 
     let guard = MUTEX.lock().unwrap_or_else(|err| err.into_inner());
 
-    if DEVICE.load().is_none() {
+    SET_ENV.call_once(|| {
         std::env::set_var("P11NETHSM_CONFIG_FILE", "../p11nethsm.conf");
+    });
+
+    guard
+}
+
+#[cfg(test)]
+pub fn init_for_tests() -> std::sync::MutexGuard<'static, ()> {
+    use std::ptr;
+
+    use crate::{api::C_Initialize, data::DEVICE};
+
+    let guard = init_lock();
+
+    if DEVICE.load().is_none() {
         assert_eq!(C_Initialize(ptr::null_mut()), cryptoki_sys::CKR_OK);
     }
 

--- a/pkcs11/src/config/initialization.rs
+++ b/pkcs11/src/config/initialization.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use super::{
-    config_file::{config_files, ConfigError, SlotConfig},
+    config_file::{config_files, ConfigError, P11Config, SlotConfig},
     device::{Device, Slot},
 };
 use arc_swap::ArcSwap;
@@ -40,7 +40,7 @@ pub enum InitializationError {
 
 pub fn initialize_with_configs(
     configs: Result<Vec<(Vec<u8>, PathBuf)>, ConfigError>,
-) -> Result<Device, InitializationError> {
+) -> Result<(Device, P11Config), InitializationError> {
     // Use a closure called immediately so that `?` can be used
     let config_res = (|| {
         let configs_files = configs.map_err(InitializationError::Config)?;
@@ -62,10 +62,10 @@ pub fn initialize_with_configs(
     for slot in config.slots.iter() {
         slots.push(Arc::new(slot_from_config(slot)?));
     }
-    Ok(Device { slots })
+    Ok((Device { slots }, config))
 }
 
-pub fn initialize() -> Result<Device, InitializationError> {
+pub fn initialize() -> Result<(Device, P11Config), InitializationError> {
     rustls::crypto::ring::default_provider()
         .install_default()
         .ok();
@@ -368,12 +368,14 @@ slots:
       count: 10
       delay_seconds: 1
     timeout_seconds: 10
+disable_thread_pool: true
             "#;
         let config_path = "/path/to/config.conf";
         let configs = vec![(config_content.into(), config_path.into())];
 
-        let device = initialize_with_configs(Ok(configs)).unwrap();
+        let (device, config) = initialize_with_configs(Ok(configs)).unwrap();
         assert_eq!(device.slots[0].certificate_format, CertificateFormat::Der);
+        assert_eq!(config.disable_thread_pool, Some(true));
 
         let config_bad_fingerprint_content = r#"
 slots:

--- a/pkcs11/src/data.rs
+++ b/pkcs11/src/data.rs
@@ -31,6 +31,7 @@ pub static EVENTS_MANAGER: RwLock<EventsManager> = RwLock::new(EventsManager::ne
 
 // If the calling application allows threads to be used
 pub static THREADS_ALLOWED: AtomicBool = AtomicBool::new(true);
+pub static THREAD_POOL_ALLOWED: AtomicBool = AtomicBool::new(true);
 
 pub static mut FN_LIST: CK_FUNCTION_LIST = CK_FUNCTION_LIST {
     version: DEVICE_VERSION,

--- a/pkcs11/src/lib.rs
+++ b/pkcs11/src/lib.rs
@@ -14,3 +14,9 @@ mod unwind_stubs;
 
 #[macro_use]
 extern crate std;
+
+const _VERSION_ASSERT: () = {
+    // if the cryptoki version is updated, we need to review the specification for relevant changes
+    assert!(defs::CRYPTOKI_VERSION.major == 3);
+    assert!(defs::CRYPTOKI_VERSION.minor == 2);
+};


### PR DESCRIPTION
This PR fixes multiple problems with the argument handling in C_Initialize:
- Previously, we checked for an outdated cryptoki version so the arguments were never actually read (since v2.1.0). As this is a compile time constant, I moved the check to a const assertion.
- We did not update the thread state if args was null so we would just use the state from the previous C_Initialize call.
- We did not spawn the background threads if args was null.
- We only checked the `CreateMutex` argument but not `DestroyMutex`, `LockMutex` and `UnlockMutex`.

It also adds two new config options, `disable_threads` and `disable_thread_pool`, to work around https://github.com/Nitrokey/nethsm-pkcs11/issues/327.

Fixes: https://github.com/Nitrokey/nethsm-pkcs11/issues/325
Fixes: https://github.com/Nitrokey/nethsm-pkcs11/issues/326